### PR TITLE
feat: add macro analysis result persistence

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -46,6 +46,15 @@ Environment variables:
   - `write_macro_series_points(points)`
   - `read_macro_series_points(metric_key, limit)`
 
+## Macro Analysis Persistence (v1)
+
+- LLM/agent 기반 매크로 분석 결과 저장 테이블: `macro_analysis_results`
+- 마이그레이션: `migrations/005_macro_analysis_results.sql`
+- Repository API:
+  - `write_macro_analysis_result(result)`
+  - `read_latest_macro_analysis(limit)`
+- 저장 필드에는 `regime`, `confidence`, `base/bull/bear`, `reason_codes`, `risk_flags`, `triggers`, `narrative`, `model` 포함
+
 ## Operator Dashboard
 
 - Run: `streamlit run src/dashboard/app.py`

--- a/migrations/005_macro_analysis_results.sql
+++ b/migrations/005_macro_analysis_results.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS macro_analysis_results (
+    id BIGSERIAL PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    as_of TIMESTAMPTZ NOT NULL,
+    regime TEXT NOT NULL,
+    confidence DOUBLE PRECISION NOT NULL,
+    base_case TEXT NOT NULL,
+    bull_case TEXT NOT NULL,
+    bear_case TEXT NOT NULL,
+    reason_codes JSONB NOT NULL,
+    risk_flags JSONB NOT NULL,
+    triggers JSONB NOT NULL,
+    narrative TEXT NOT NULL,
+    model TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_macro_analysis_results_as_of_created
+ON macro_analysis_results(as_of DESC, created_at DESC);

--- a/tests/test_macro_analysis_repository.py
+++ b/tests/test_macro_analysis_repository.py
@@ -1,0 +1,109 @@
+import importlib
+
+
+postgres_repository = importlib.import_module("src.ingestion.postgres_repository")
+PostgresRepository = postgres_repository.PostgresRepository
+
+
+class FakeCursor:
+    def __init__(self, fetch_rows=None, columns=None):
+        self.fetch_rows = fetch_rows or []
+        self.columns = columns or []
+        self.executed = []
+        self.description = [(name,) for name in self.columns]
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self.fetch_rows
+
+    def close(self):
+        return None
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+        self.committed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def close(self):
+        return None
+
+
+def test_postgres_repository_writes_macro_analysis_result():
+    cursor = FakeCursor()
+    conn = FakeConnection(cursor)
+    repo = PostgresRepository(connection_factory=lambda: conn)
+
+    repo.write_macro_analysis_result(
+        {
+            "run_id": "run-1",
+            "as_of": "2026-02-18T00:00:00+00:00",
+            "regime": "neutral",
+            "confidence": 0.62,
+            "base_case": "growth slows with sticky inflation",
+            "bull_case": "soft landing",
+            "bear_case": "policy mistake",
+            "reason_codes": ["cpi_cooling", "rate_plateau"],
+            "risk_flags": ["data_gap"],
+            "triggers": ["next_cpi", "fomc_minutes"],
+            "narrative": "Macro conditions are mixed with a slight slowdown bias.",
+            "model": "gpt-5.3-codex",
+        }
+    )
+
+    assert "INSERT INTO macro_analysis_results" in cursor.executed[0][0]
+    assert cursor.executed[0][1][0] == "run-1"
+    assert conn.committed is True
+
+
+def test_postgres_repository_reads_latest_macro_analysis():
+    cursor = FakeCursor(
+        fetch_rows=[
+            (
+                "run-1",
+                "2026-02-18T00:00:00+00:00",
+                "neutral",
+                0.62,
+                "growth slows",
+                "soft landing",
+                "hard landing",
+                ["cpi_cooling"],
+                ["data_gap"],
+                ["next_cpi"],
+                "narrative text",
+                "gpt-5.3-codex",
+                "2026-02-18T00:01:00+00:00",
+            )
+        ],
+        columns=[
+            "run_id",
+            "as_of",
+            "regime",
+            "confidence",
+            "base_case",
+            "bull_case",
+            "bear_case",
+            "reason_codes",
+            "risk_flags",
+            "triggers",
+            "narrative",
+            "model",
+            "created_at",
+        ],
+    )
+    conn = FakeConnection(cursor)
+    repo = PostgresRepository(connection_factory=lambda: conn)
+
+    rows = repo.read_latest_macro_analysis(limit=10)
+
+    assert "FROM macro_analysis_results" in cursor.executed[0][0]
+    assert rows[0]["run_id"] == "run-1"
+    assert rows[0]["regime"] == "neutral"


### PR DESCRIPTION
## Summary\n- add macro_analysis_results schema migration\n- add PostgresRepository write/read methods for macro analysis outputs\n- add repository tests for insert/select behavior\n- document persistence section in ingestion runbook\n\n## Validation\n- PYTHONPATH=. pytest -q (44 passed)