### PR TITLE
feat: auto-populate macro_series_points during FRED/ECOS ingestion

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -45,6 +45,9 @@ Environment variables:
 - Repository API:
   - `write_macro_series_points(points)`
   - `read_macro_series_points(metric_key, limit)`
+- 동작 규칙:
+  - `run_ingestion_job()`에서 FRED/ECOS 배치가 canonical로 승격되면 정규화 후 `macro_series_points`를 자동 적재
+  - 품질/소스 게이트 실패로 quarantine된 배치는 정규화 적재를 수행하지 않음
 
 ## Macro Analysis Persistence (v1)
 

--- a/src/ingestion/job.py
+++ b/src/ingestion/job.py
@@ -1,7 +1,9 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Protocol
+
+from src.research.normalization import normalize_payload
 
 from .pit_query import filter_point_in_time
 from .quality_gate import BatchMetrics, evaluate_quality
@@ -24,7 +26,31 @@ class IngestionRepositoryProtocol(Protocol):
 
     def write_quarantine(self, reason: str, payload: Mapping[str, object]) -> None: ...
 
+    def write_macro_series_points(self, points: list[object]) -> int: ...
+
     def snapshot_counts(self) -> dict[str, int]: ...
+
+
+def _resolve_entity_id(rows: list[dict[str, object]]) -> str:
+    if not rows:
+        return "unknown"
+    value = rows[0].get("entity_id")
+    if value is None:
+        return "unknown"
+    return str(value)
+
+
+def _resolve_available_at(rows: list[dict[str, object]], decision_time: datetime) -> datetime:
+    if not rows:
+        return decision_time
+
+    value = rows[0].get("available_at")
+    if not isinstance(value, datetime):
+        return decision_time
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
 
 
 def run_ingestion_job(
@@ -45,10 +71,24 @@ def run_ingestion_job(
     repository.write_raw(payload)
     store.put(idempotency_key, payload)
 
+    macro_series_points_written = 0
     if source_eval.admitted and quality_eval.promote:
         repository.write_canonical(payload)
         canonical_written = 1
         quarantined = 0
+
+        source_name = source.name.lower()
+        if source_name in {"fred", "ecos"}:
+            normalized_points = normalize_payload(
+                source=source_name,
+                payload=payload,
+                entity_id=_resolve_entity_id(rows),
+                available_at=_resolve_available_at(rows, decision_time),
+                lineage_id=idempotency_key,
+            )
+            macro_series_points_written = repository.write_macro_series_points(
+                normalized_points
+            )
     else:
         reason = "source_gate_failed" if not source_eval.admitted else "quality_gate_failed"
         repository.write_quarantine(reason=reason, payload=payload)
@@ -58,6 +98,7 @@ def run_ingestion_job(
     pit_rows = filter_point_in_time(rows, decision_time)
     dashboard = repository.snapshot_counts()
     dashboard["pit_rows"] = len(pit_rows)
+    dashboard["macro_series_points_written"] = macro_series_points_written
 
     return JobResult(
         raw_written=1,

--- a/src/ingestion/repository.py
+++ b/src/ingestion/repository.py
@@ -6,6 +6,7 @@ class InMemoryRepository:
         self.raw_events: list[dict[str, object]] = []
         self.canonical_events: list[dict[str, object]] = []
         self.quarantine_events: list[dict[str, object]] = []
+        self.macro_series_points: list[dict[str, object]] = []
 
     def write_raw(self, row: Mapping[str, object]) -> None:
         self.raw_events.append(dict(row))
@@ -15,6 +16,21 @@ class InMemoryRepository:
 
     def write_quarantine(self, reason: str, payload: Mapping[str, object]) -> None:
         self.quarantine_events.append({"reason": reason, "payload": dict(payload)})
+
+    def write_macro_series_points(self, points: list[object]) -> int:
+        for point in points:
+            self.macro_series_points.append(
+                {
+                    "source": getattr(point, "source", "unknown"),
+                    "entity_id": getattr(point, "entity_id", "unknown"),
+                    "metric_key": getattr(point, "metric_key", "unknown"),
+                    "as_of": getattr(point, "as_of", None),
+                    "available_at": getattr(point, "available_at", None),
+                    "value": getattr(point, "value", None),
+                    "lineage_id": getattr(point, "lineage_id", None),
+                }
+            )
+        return len(points)
 
     def read_canonical_facts(
         self, source: str, metric_name: str, limit: int = 12
@@ -31,4 +47,5 @@ class InMemoryRepository:
             "raw_events": len(self.raw_events),
             "canonical_events": len(self.canonical_events),
             "quarantine_events": len(self.quarantine_events),
+            "macro_series_points": len(self.macro_series_points),
         }

--- a/tests/test_ingestion_job.py
+++ b/tests/test_ingestion_job.py
@@ -87,3 +87,51 @@ def test_ingestion_job_quarantines_when_quality_fails():
     assert result.canonical_written == 0
     assert result.quarantined == 1
     assert result.dashboard["quarantine_events"] == 1
+    assert result.dashboard["macro_series_points_written"] == 0
+
+
+def test_ingestion_job_writes_macro_series_points_for_fred_source():
+    repo = InMemoryRepository()
+    source = SourceDescriptor(
+        name="fred",
+        utility=5,
+        reliability=5,
+        legal=5,
+        cost=3,
+        maintenance=3,
+    )
+    metrics = BatchMetrics(
+        freshness=True,
+        completeness=True,
+        schema_drift=False,
+        license_ok=True,
+    )
+
+    result = run_ingestion_job(
+        source=source,
+        metrics=metrics,
+        idempotency_key="fred|UNRATE|2026-01-01|r1",
+        payload={
+            "payload": {
+                "observations": [
+                    {"date": "2025-12-01", "value": "4.4"},
+                    {"date": "2026-01-01", "value": "4.3"},
+                ]
+            }
+        },
+        rows=[
+            {
+                "entity_id": "UNRATE",
+                "as_of": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                "available_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+            }
+        ],
+        decision_time=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        repository=repo,
+    )
+
+    assert result.canonical_written == 1
+    assert result.quarantined == 0
+    assert result.dashboard["macro_series_points_written"] == 2
+    assert len(repo.macro_series_points) == 2
+    assert repo.macro_series_points[-1]["metric_key"] == "UNRATE"


### PR DESCRIPTION
## Summary
- wire normalization into `run_ingestion_job()` for admitted FRED/ECOS batches
- persist normalized points via `write_macro_series_points()` automatically
- add dashboard field `macro_series_points_written` per run
- extend in-memory repository support for macro series writes
- add ingestion job tests for FRED auto-normalization path
- document the automatic behavior in ingestion runbook

## Why
`macro_series_points` remained under-populated because normalization persistence was not connected to the ingestion job flow. This connects that missing path while keeping quarantine behavior unchanged.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (48 passed)
