### PR TITLE
feat(normalization): support quarterly/yearly TIME keys

### DIFF
--- a/src/research/normalization.py
+++ b/src/research/normalization.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timezone
 from typing import Iterable, Mapping, Optional
 
@@ -12,12 +13,19 @@ def _parse_datetime(value: object) -> Optional[datetime]:
     if not isinstance(value, str) or not value:
         return None
 
-    for fmt in ("%Y-%m-%d", "%Y%m", "%Y-%m", "%Y%m%d"):
+    for fmt in ("%Y-%m-%d", "%Y%m", "%Y-%m", "%Y%m%d", "%Y"):
         try:
             dt = datetime.strptime(value, fmt)
             return dt.replace(tzinfo=timezone.utc)
         except ValueError:
             pass
+
+    quarter_match = re.fullmatch(r"(\d{4})-?Q([1-4])", value.strip(), flags=re.IGNORECASE)
+    if quarter_match:
+        year = int(quarter_match.group(1))
+        quarter = int(quarter_match.group(2))
+        month = (quarter - 1) * 3 + 1
+        return datetime(year, month, 1, tzinfo=timezone.utc)
 
     try:
         dt = datetime.fromisoformat(value)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -49,13 +49,40 @@ def test_normalize_ecos_payload_skips_malformed_rows():
     assert points[0].value == 100.1
 
 
+def test_normalize_ecos_payload_supports_quarter_and_year_time_keys():
+    points = normalization.normalize_payload(
+        source="ecos",
+        payload={
+            "payload": {
+                "StatisticSearch": {
+                    "row": [
+                        {"TIME": "2024Q3", "DATA_VALUE": "101.3", "ITEM_NAME1": "KOR_GDP"},
+                        {"TIME": "2024", "DATA_VALUE": "99.9", "ITEM_NAME1": "KOR_GDP"},
+                        {"TIME": "2024-Q1", "DATA_VALUE": "100.2", "ITEM_NAME1": "KOR_GDP"},
+                    ]
+                }
+            }
+        },
+        entity_id="200Y001",
+        available_at=datetime(2026, 2, 18, tzinfo=timezone.utc),
+        lineage_id="lin-3",
+    )
+
+    assert len(points) == 3
+    assert [p.as_of.strftime("%Y-%m-%d") for p in points] == [
+        "2024-01-01",
+        "2024-01-01",
+        "2024-07-01",
+    ]
+
+
 def test_normalize_payload_unsupported_source_returns_empty():
     points = normalization.normalize_payload(
         source="sec_edgar",
         payload={"payload": {}},
         entity_id="0000320193",
         available_at=datetime(2026, 2, 18, tzinfo=timezone.utc),
-        lineage_id="lin-3",
+        lineage_id="lin-4",
     )
 
     assert points == []


### PR DESCRIPTION
## Summary
- extend normalization datetime parser to support yearly keys (`YYYY`)
- support quarterly ECOS/FRED-style keys (`YYYYQn`, `YYYY-Qn`)
- add unit test coverage for quarter/year ECOS `TIME` formats

## Why
Some macro series are quarterly/yearly and were dropped during normalization due to unsupported date formats. This improves `macro_series_points` coverage without changing existing monthly/daily behavior.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (50 passed)
