### PR TITLE
feat: add CLI query for expected-vs-realized learning-loop rows

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,5 +1,7 @@
 import importlib
 
+import pytest
+
 
 cli = importlib.import_module("src.ingestion.cli")
 
@@ -10,3 +12,38 @@ def test_cli_exposes_manual_update_command():
 
     assert args.command == "run-update"
     assert args.source == "sec_edgar"
+
+
+def test_cli_exposes_expected_vs_realized_command_with_defaults():
+    parser = cli.build_parser()
+    args = parser.parse_args(["expected-vs-realized"])
+
+    assert args.command == "expected-vs-realized"
+    assert args.horizon == "1M"
+    assert args.limit == 50
+
+
+def test_read_expected_vs_realized_command_requires_database_url(monkeypatch):
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(ValueError):
+        cli.read_expected_vs_realized_command()
+
+
+def test_read_expected_vs_realized_command_uses_postgres_repository(monkeypatch):
+    class FakeRepository:
+        def __init__(self, dsn: str) -> None:
+            self.dsn = dsn
+
+        def read_expected_vs_realized(self, horizon: str, limit: int):
+            assert horizon == "3M"
+            assert limit == 10
+            return [{"horizon": horizon, "limit": limit, "dsn": self.dsn}]
+
+    monkeypatch.setenv("DATABASE_URL", "postgres://example")
+    monkeypatch.setattr(cli, "PostgresRepository", FakeRepository)
+
+    rows = cli.read_expected_vs_realized_command(horizon="3M", limit=10)
+
+    assert rows == [{"horizon": "3M", "limit": 10, "dsn": "postgres://example"}]


### PR DESCRIPTION
## Why
To improve evidence traceability and learning-loop operability, we need a simple operator entry point to fetch forecast vs realized rows directly from the DB.

## What
- Added new ingestion CLI subcommand: 
- Supports  (default ) and  (default )
- Added  that requires DB DSN and reads from 
- Added smoke/unit tests for parser defaults, missing-DSN guard, and repository invocation

## Validation
- ..............................................................           [100%]
62 passed in 0.18s
- Result: 62 passed
