### PR TITLE
feat: expose 1M forecast learning metrics in operator dashboard

### DIFF
--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -6,6 +6,8 @@ class DashboardRepositoryProtocol(Protocol):
 
     def read_status_counters(self) -> dict[str, int]: ...
 
+    def read_learning_metrics(self, horizon: str = "1M") -> dict[str, object]: ...
+
 
 def build_dashboard_view(
     repository: DashboardRepositoryProtocol,
@@ -13,6 +15,7 @@ def build_dashboard_view(
 ) -> dict[str, object]:
     recent_runs = repository.read_latest_runs(limit=limit)
     counters = repository.read_status_counters()
+    learning_metrics = repository.read_learning_metrics(horizon="1M")
 
     if recent_runs:
         latest = recent_runs[0]
@@ -26,5 +29,6 @@ def build_dashboard_view(
         "last_run_status": last_run_status,
         "last_run_time": last_run_time,
         "counters": counters,
+        "learning_metrics": learning_metrics,
         "recent_runs": recent_runs,
     }

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -18,6 +18,12 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "canonical_events": 90,
                 "quarantine_events": 10,
             },
+            "learning_metrics": {
+                "horizon": "1M",
+                "realized_count": 10,
+                "hit_rate": 0.6,
+                "mean_abs_forecast_error": 0.025,
+            },
             "recent_runs": [],
         }
     )
@@ -25,3 +31,6 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["last_run_status"] == "success"
     assert cards["raw_events"] == 100
     assert cards["quarantine_events"] == 10
+    assert cards["realized_count"] == 10
+    assert cards["hit_rate_pct"] == "60.0%"
+    assert cards["mae_pct"] == "2.50%"

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -15,6 +15,14 @@ class FakeDashboardRepo:
     def read_status_counters(self):
         return {"raw_events": 100, "canonical_events": 90, "quarantine_events": 10}
 
+    def read_learning_metrics(self, horizon="1M"):
+        return {
+            "horizon": horizon,
+            "realized_count": 12,
+            "hit_rate": 0.58,
+            "mean_abs_forecast_error": 0.031,
+        }
+
 
 def test_dashboard_service_builds_operator_view_model():
     view = build_dashboard_view(FakeDashboardRepo())
@@ -22,4 +30,6 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["last_run_status"] == "success"
     assert view["last_run_time"] == "2026-02-18T01:00:00Z"
     assert view["counters"]["raw_events"] == 100
+    assert view["learning_metrics"]["horizon"] == "1M"
+    assert view["learning_metrics"]["hit_rate"] == 0.58
     assert len(view["recent_runs"]) == 2


### PR DESCRIPTION
## Why
We need tighter forecast learning-loop visibility in the operator view so expected-vs-realized quality can be tracked without querying DB manually.

## What
- Added `read_learning_metrics(horizon="1M")` in `PostgresRepository`.
  - Computes realized sample count
  - Computes hit rate (`realization_records.hit`)
  - Computes mean absolute forecast error (`ABS(forecast_error)`)
- Extended dashboard service view model to include `learning_metrics`.
- Updated Streamlit operator cards to display:
  - 1M Realized count
  - 1M Hit Rate
  - 1M MAE
- Added/updated tests for repository, dashboard service, and dashboard cards.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `63 passed`

## Policy alignment
- Keeps learning-loop focus on primary 1M horizon
- Preserves HARD/SOFT evidence separation (no schema mixing introduced)
