### PR TITLE
feat: add HARD/SOFT evidence fields to macro analysis results

### DIFF
--- a/migrations/009_macro_analysis_evidence_fields.sql
+++ b/migrations/009_macro_analysis_evidence_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE macro_analysis_results
+ADD COLUMN IF NOT EXISTS evidence_hard JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE macro_analysis_results
+ADD COLUMN IF NOT EXISTS evidence_soft JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/src/ingestion/postgres_repository.py
+++ b/src/ingestion/postgres_repository.py
@@ -101,9 +101,11 @@ class PostgresRepository:
                 reason_codes,
                 risk_flags,
                 triggers,
+                evidence_hard,
+                evidence_soft,
                 narrative,
                 model
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s)
             """,
             (
                 result["run_id"],
@@ -118,6 +120,8 @@ class PostgresRepository:
                 json.dumps(result["reason_codes"], default=str),
                 json.dumps(result["risk_flags"], default=str),
                 json.dumps(result["triggers"], default=str),
+                json.dumps(result.get("evidence_hard", []), default=str),
+                json.dumps(result.get("evidence_soft", []), default=str),
                 result["narrative"],
                 result.get("model"),
             ),
@@ -144,6 +148,8 @@ class PostgresRepository:
                 reason_codes,
                 risk_flags,
                 triggers,
+                evidence_hard,
+                evidence_soft,
                 narrative,
                 model,
                 created_at

--- a/tests/test_macro_analysis_evidence_fields_migration.py
+++ b/tests/test_macro_analysis_evidence_fields_migration.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_macro_analysis_results_migration_adds_hard_soft_evidence_fields():
+    sql = Path("migrations/009_macro_analysis_evidence_fields.sql").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ALTER TABLE macro_analysis_results" in sql
+    assert "ADD COLUMN IF NOT EXISTS evidence_hard JSONB" in sql
+    assert "ADD COLUMN IF NOT EXISTS evidence_soft JSONB" in sql

--- a/tests/test_macro_analysis_repository.py
+++ b/tests/test_macro_analysis_repository.py
@@ -56,6 +56,8 @@ def test_postgres_repository_writes_macro_analysis_result():
             "reason_codes": ["cpi_cooling", "rate_plateau"],
             "risk_flags": ["data_gap"],
             "triggers": ["next_cpi", "fomc_minutes"],
+            "evidence_hard": [{"source": "fred", "series": "CPIAUCSL"}],
+            "evidence_soft": [{"source": "news", "title": "Soft landing odds rise"}],
             "narrative": "Macro conditions are mixed with a slight slowdown bias.",
             "model": "gpt-5.3-codex",
         }
@@ -67,6 +69,8 @@ def test_postgres_repository_writes_macro_analysis_result():
     assert cursor.executed[0][1][0] == "run-1"
     assert cursor.executed[0][1][7] == "policy hold then cuts"
     assert cursor.executed[0][1][8] == "both sides underweight liquidity"
+    assert '"CPIAUCSL"' in cursor.executed[0][1][12]
+    assert '"Soft landing odds rise"' in cursor.executed[0][1][13]
     assert conn.committed is True
 
 
@@ -94,6 +98,8 @@ def test_postgres_repository_writes_macro_analysis_result_with_optional_fields_d
 
     assert cursor.executed[0][1][7] == ""
     assert cursor.executed[0][1][8] == ""
+    assert cursor.executed[0][1][12] == "[]"
+    assert cursor.executed[0][1][13] == "[]"
 
 
 def test_postgres_repository_reads_latest_macro_analysis():
@@ -112,6 +118,8 @@ def test_postgres_repository_reads_latest_macro_analysis():
                 ["cpi_cooling"],
                 ["data_gap"],
                 ["next_cpi"],
+                [{"source": "fred", "series": "CPIAUCSL"}],
+                [{"source": "news", "title": "Soft landing odds rise"}],
                 "narrative text",
                 "gpt-5.3-codex",
                 "2026-02-18T00:01:00+00:00",
@@ -130,6 +138,8 @@ def test_postgres_repository_reads_latest_macro_analysis():
             "reason_codes",
             "risk_flags",
             "triggers",
+            "evidence_hard",
+            "evidence_soft",
             "narrative",
             "model",
             "created_at",
@@ -145,3 +155,5 @@ def test_postgres_repository_reads_latest_macro_analysis():
     assert rows[0]["regime"] == "neutral"
     assert rows[0]["policy_case"] == "policy hold then cuts"
     assert rows[0]["critic_case"] == "both sides underweight liquidity"
+    assert rows[0]["evidence_hard"][0]["series"] == "CPIAUCSL"
+    assert rows[0]["evidence_soft"][0]["source"] == "news"


### PR DESCRIPTION
## Why
Macro analysis outputs should keep HARD facts and SOFT interpretation explicitly separated for evidence-traceable decisions, consistent with project ground rules.

## What
- Added migration  to add  and  JSONB columns to 
- Updated  to persist both evidence fields (with safe default empty arrays)
- Updated  to return both evidence fields
- Expanded repository tests and added migration test

## Validation
- ................................................................         [100%]
64 passed in 0.19s
- Result: 
