### PR TITLE
feat: track 1M forecast realization coverage in dashboard

### DIFF
--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -20,7 +20,9 @@ def test_dashboard_app_builds_cards_from_view_model():
             },
             "learning_metrics": {
                 "horizon": "1M",
+                "forecast_count": 25,
                 "realized_count": 10,
+                "realization_coverage": 0.4,
                 "hit_rate": 0.6,
                 "mean_abs_forecast_error": 0.025,
             },
@@ -31,6 +33,8 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["last_run_status"] == "success"
     assert cards["raw_events"] == 100
     assert cards["quarantine_events"] == 10
+    assert cards["forecast_count"] == 25
     assert cards["realized_count"] == 10
+    assert cards["coverage_pct"] == "40.0%"
     assert cards["hit_rate_pct"] == "60.0%"
     assert cards["mae_pct"] == "2.50%"

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -18,7 +18,9 @@ class FakeDashboardRepo:
     def read_learning_metrics(self, horizon="1M"):
         return {
             "horizon": horizon,
+            "forecast_count": 20,
             "realized_count": 12,
+            "realization_coverage": 0.6,
             "hit_rate": 0.58,
             "mean_abs_forecast_error": 0.031,
         }


### PR DESCRIPTION
## Why
- Learning-loop quality needs visibility into how many 1M forecasts have actually matured into realizations.
- Hit rate/MAE alone can look stable even when sample coverage is too low.

## What
- Added forecast_count query to read_learning_metrics(horizon).
- Added derived realization_coverage (= realized_count / forecast_count, nullable when no forecasts).
- Exposed coverage in operator dashboard cards (1M Forecasts, 1M Coverage).
- Updated repository and dashboard tests.

## Validation
- FRED_API_KEY= ECOS_API_KEY= pytest -q
- Result: 67 passed

## Policy alignment
- Keeps HARD/SOFT separation unchanged.
- Improves evidence traceability for learning-loop monitoring without altering execution behavior.
