### PR TITLE
Enforce non-empty HARD evidence for thesis/forecast writes

### DIFF
--- a/src/ingestion/postgres_repository.py
+++ b/src/ingestion/postgres_repository.py
@@ -40,6 +40,16 @@ class PostgresRepository:
             connection_factory
         )
 
+    @staticmethod
+    def _require_hard_evidence(
+        evidence_hard: object,
+        context: str,
+    ) -> None:
+        if not isinstance(evidence_hard, list) or len(evidence_hard) == 0:
+            raise ValueError(
+                f"{context} requires non-empty evidence_hard (HARD evidence)"
+            )
+
     def _connect(self) -> ConnectionProtocol:
         if self._connection_factory is not None:
             return self._connection_factory()
@@ -166,6 +176,10 @@ class PostgresRepository:
         return [dict(zip(columns, row)) for row in rows]
 
     def write_investment_thesis(self, thesis: Mapping[str, object]) -> str:
+        self._require_hard_evidence(
+            thesis.get("evidence_hard"),
+            "investment thesis",
+        )
         conn: ConnectionProtocol = self._connect()
         cursor: CursorProtocol = conn.cursor()
         cursor.execute(
@@ -214,6 +228,10 @@ class PostgresRepository:
         return str(row[0])
 
     def write_forecast_record(self, record: Mapping[str, object]) -> int:
+        self._require_hard_evidence(
+            record.get("evidence_hard"),
+            "forecast record",
+        )
         conn: ConnectionProtocol = self._connect()
         cursor: CursorProtocol = conn.cursor()
         cursor.execute(

--- a/tests/test_postgres_repository.py
+++ b/tests/test_postgres_repository.py
@@ -173,6 +173,61 @@ def test_postgres_repository_writes_forecast_record_and_returns_id():
     assert conn.committed is True
 
 
+def test_postgres_repository_rejects_investment_thesis_without_hard_evidence():
+    cursor = FakeCursor(fetch_one_rows=[("thesis-1",)])
+    conn = FakeConnection(cursor)
+    repo = PostgresRepository(connection_factory=lambda: conn)
+
+    try:
+        repo.write_investment_thesis(
+            {
+                "thesis_id": "thesis-1",
+                "created_by": "autopilot",
+                "scope_level": "stock",
+                "target_id": "AAPL",
+                "title": "AI capex cycle persists",
+                "summary": "Cloud demand and margins support overweight.",
+                "evidence_hard": [],
+                "evidence_soft": [{"source": "news", "note": "tone improved"}],
+                "as_of": "2026-02-22T00:00:00+00:00",
+                "lineage_id": "lineage-1",
+            }
+        )
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "investment thesis requires non-empty evidence_hard" in str(exc)
+
+    assert cursor.executed == []
+
+
+def test_postgres_repository_rejects_forecast_record_without_hard_evidence():
+    cursor = FakeCursor(fetch_one_rows=[(42,)])
+    conn = FakeConnection(cursor)
+    repo = PostgresRepository(connection_factory=lambda: conn)
+
+    try:
+        repo.write_forecast_record(
+            {
+                "thesis_id": "thesis-1",
+                "horizon": "1M",
+                "expected_return_low": 0.04,
+                "expected_return_high": 0.10,
+                "expected_volatility": 0.2,
+                "expected_drawdown": 0.12,
+                "confidence": 0.7,
+                "key_drivers": ["macro:disinflation"],
+                "evidence_hard": [],
+                "evidence_soft": [{"source": "news", "note": "AI capex sentiment"}],
+                "as_of": "2026-02-22T00:00:00+00:00",
+            }
+        )
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "forecast record requires non-empty evidence_hard" in str(exc)
+
+    assert cursor.executed == []
+
+
 def test_postgres_repository_computes_realization_hit_and_forecast_error_from_forecast_range():
     cursor = FakeCursor(fetch_one_rows=[(0.02, 0.08), (99,)])
     conn = FakeConnection(cursor)


### PR DESCRIPTION
## Why
Ground rules require HARD/SOFT separation and prohibit investment execution conclusions without HARD evidence. This change enforces that contract at write-time for core learning-loop records.

## What
- Added `PostgresRepository._require_hard_evidence(...)` guard.
- Enforced guard in:
  - `write_investment_thesis`
  - `write_forecast_record`
- Added tests to verify both methods reject empty `evidence_hard` and avoid SQL execution.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `69 passed`
