### PR TITLE
feat: surface 1M forecast-error attribution summary on dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -39,6 +39,16 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         hit_rate = None
         mae = None
 
+    attribution_summary = view.get("attribution_summary", {})
+    if isinstance(attribution_summary, Mapping):
+        attribution_total = to_int(attribution_summary.get("total", 0))
+        top_category = str(attribution_summary.get("top_category", "n/a"))
+        top_count = to_int(attribution_summary.get("top_count", 0))
+    else:
+        attribution_total = 0
+        top_category = "n/a"
+        top_count = 0
+
     coverage_pct = "n/a" if not isinstance(realization_coverage, (int, float)) else f"{realization_coverage * 100:.1f}%"
     hit_rate_pct = "n/a" if not isinstance(hit_rate, (int, float)) else f"{hit_rate * 100:.1f}%"
     mae_pct = "n/a" if not isinstance(mae, (int, float)) else f"{mae * 100:.2f}%"
@@ -54,6 +64,9 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         "coverage_pct": coverage_pct,
         "hit_rate_pct": hit_rate_pct,
         "mae_pct": mae_pct,
+        "attribution_total": attribution_total,
+        "attribution_top_category": top_category,
+        "attribution_top_count": top_count,
     }
 
 
@@ -75,7 +88,7 @@ def run_streamlit_app(dsn: str) -> None:
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 
-    c1, c2, c3, c4, c5, c6, c7, c8, c9 = st.columns(9)
+    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11 = st.columns(11)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
     c2.metric("Raw", cards["raw_events"])
     c3.metric("Canonical", cards["canonical_events"])
@@ -85,6 +98,8 @@ def run_streamlit_app(dsn: str) -> None:
     c7.metric("1M Coverage", cards["coverage_pct"])
     c8.metric("1M Hit Rate", cards["hit_rate_pct"])
     c9.metric("1M MAE", cards["mae_pct"])
+    c10.metric("1M Attr", cards["attribution_total"])
+    c11.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
 
     recent_runs = view.get("recent_runs", [])
     if isinstance(recent_runs, list) and recent_runs:

--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import Protocol
 
 
@@ -17,6 +18,27 @@ def build_dashboard_view(
     counters = repository.read_status_counters()
     learning_metrics = repository.read_learning_metrics(horizon="1M")
 
+    attribution_summary = {
+        "total": 0,
+        "top_category": "n/a",
+        "top_count": 0,
+    }
+    if hasattr(repository, "read_forecast_error_attributions"):
+        attribution_rows = repository.read_forecast_error_attributions(horizon="1M", limit=200)
+        categories = [
+            str(row.get("category", "unknown"))
+            for row in attribution_rows
+            if isinstance(row, dict) and row.get("category")
+        ]
+        category_counts = Counter(categories)
+        if category_counts:
+            top_category, top_count = category_counts.most_common(1)[0]
+            attribution_summary = {
+                "total": len(attribution_rows),
+                "top_category": top_category,
+                "top_count": int(top_count),
+            }
+
     if recent_runs:
         latest = recent_runs[0]
         last_run_status = str(latest.get("status", "unknown"))
@@ -30,5 +52,6 @@ def build_dashboard_view(
         "last_run_time": last_run_time,
         "counters": counters,
         "learning_metrics": learning_metrics,
+        "attribution_summary": attribution_summary,
         "recent_runs": recent_runs,
     }

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -26,6 +26,11 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "hit_rate": 0.6,
                 "mean_abs_forecast_error": 0.025,
             },
+            "attribution_summary": {
+                "total": 7,
+                "top_category": "macro_miss",
+                "top_count": 3,
+            },
             "recent_runs": [],
         }
     )
@@ -38,3 +43,6 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["coverage_pct"] == "40.0%"
     assert cards["hit_rate_pct"] == "60.0%"
     assert cards["mae_pct"] == "2.50%"
+    assert cards["attribution_total"] == 7
+    assert cards["attribution_top_category"] == "macro_miss"
+    assert cards["attribution_top_count"] == 3

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -25,6 +25,13 @@ class FakeDashboardRepo:
             "mean_abs_forecast_error": 0.031,
         }
 
+    def read_forecast_error_attributions(self, horizon="1M", limit=200):
+        return [
+            {"category": "macro_miss"},
+            {"category": "macro_miss"},
+            {"category": "valuation_miss"},
+        ]
+
 
 def test_dashboard_service_builds_operator_view_model():
     view = build_dashboard_view(FakeDashboardRepo())
@@ -34,4 +41,7 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["counters"]["raw_events"] == 100
     assert view["learning_metrics"]["horizon"] == "1M"
     assert view["learning_metrics"]["hit_rate"] == 0.58
+    assert view["attribution_summary"]["total"] == 3
+    assert view["attribution_summary"]["top_category"] == "macro_miss"
+    assert view["attribution_summary"]["top_count"] == 2
     assert len(view["recent_runs"]) == 2


### PR DESCRIPTION
## Why
Operator dashboard had 1M realization quality metrics, but no quick signal for forecast-error attribution concentration. This made it harder to spot dominant failure modes in the learning loop.

## What
- Extend `build_dashboard_view` to compute a 1M attribution summary from forecast-error attribution rows.
- Add summary fields: total attributions, top category, and top-category count.
- Surface two new dashboard cards: `1M Attr` and `Top Attr`.
- Add/extend smoke + service tests for the new fields.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `69 passed`
