### PR TITLE
Add attribution category stats for learning diagnostics

### DIFF
--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -9,6 +9,10 @@ class DashboardRepositoryProtocol(Protocol):
 
     def read_learning_metrics(self, horizon: str = "1M") -> dict[str, object]: ...
 
+    def read_forecast_error_category_stats(
+        self, horizon: str = "1M", limit: int = 5
+    ) -> list[dict[str, object]]: ...
+
 
 def build_dashboard_view(
     repository: DashboardRepositoryProtocol,
@@ -22,8 +26,19 @@ def build_dashboard_view(
         "total": 0,
         "top_category": "n/a",
         "top_count": 0,
+        "top_categories": [],
     }
-    if hasattr(repository, "read_forecast_error_attributions"):
+    if hasattr(repository, "read_forecast_error_category_stats"):
+        category_stats = repository.read_forecast_error_category_stats(horizon="1M", limit=5)
+        if category_stats:
+            top = category_stats[0]
+            attribution_summary = {
+                "total": int(sum(int(row.get("attribution_count", 0)) for row in category_stats)),
+                "top_category": str(top.get("category", "n/a")),
+                "top_count": int(top.get("attribution_count", 0)),
+                "top_categories": category_stats,
+            }
+    elif hasattr(repository, "read_forecast_error_attributions"):
         attribution_rows = repository.read_forecast_error_attributions(horizon="1M", limit=200)
         categories = [
             str(row.get("category", "unknown"))
@@ -37,6 +52,10 @@ def build_dashboard_view(
                 "total": len(attribution_rows),
                 "top_category": top_category,
                 "top_count": int(top_count),
+                "top_categories": [
+                    {"category": key, "attribution_count": int(value)}
+                    for key, value in category_counts.most_common(5)
+                ],
             }
 
     if recent_runs:

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -25,11 +25,20 @@ class FakeDashboardRepo:
             "mean_abs_forecast_error": 0.031,
         }
 
-    def read_forecast_error_attributions(self, horizon="1M", limit=200):
+    def read_forecast_error_category_stats(self, horizon="1M", limit=5):
         return [
-            {"category": "macro_miss"},
-            {"category": "macro_miss"},
-            {"category": "valuation_miss"},
+            {
+                "category": "macro_miss",
+                "attribution_count": 2,
+                "mean_contribution": -0.021,
+                "mean_abs_contribution": 0.021,
+            },
+            {
+                "category": "valuation_miss",
+                "attribution_count": 1,
+                "mean_contribution": -0.008,
+                "mean_abs_contribution": 0.008,
+            },
         ]
 
 
@@ -44,4 +53,6 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["attribution_summary"]["total"] == 3
     assert view["attribution_summary"]["top_category"] == "macro_miss"
     assert view["attribution_summary"]["top_count"] == 2
+    assert len(view["attribution_summary"]["top_categories"]) == 2
+    assert view["attribution_summary"]["top_categories"][0]["mean_abs_contribution"] == 0.021
     assert len(view["recent_runs"]) == 2


### PR DESCRIPTION
## Why
Improve forecast-error attribution learning loop by exposing structured category-level diagnostics (count + contribution averages) for 1M horizon monitoring.

## What
- Added `read_forecast_error_category_stats` to `PostgresRepository`
- Updated dashboard view to prefer aggregated category stats and include `top_categories`
- Kept fallback path using raw attribution rows when aggregate API is unavailable
- Added/updated unit tests for repository and dashboard behavior

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- `70 passed`
