### PR TITLE
test: make CanonicalDataClient no-DB fallback deterministic

### DIFF
--- a/tests/test_analysis_data_client.py
+++ b/tests/test_analysis_data_client.py
@@ -7,6 +7,8 @@ def test_canonical_data_client_falls_back_without_db(
 ) -> None:
     monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    monkeypatch.delenv("ECOS_API_KEY", raising=False)
 
     client = CanonicalDataClient()
     rows = client.read_series("fred", "CPIAUCSL", limit=5)


### PR DESCRIPTION
## Why
Host environments may have / set globally, causing  to fetch live API data even when DB env vars are removed. This makes the no-DB fallback test flaky and non-deterministic.

## What
- In , also clear  and  via .

## Validation
- ......................................................................   [100%]
70 passed in 0.20s (70 passed)

This keeps test behavior deterministic and prevents external SOFT/HARD source mixing from host env leakage during CI/test runs.