### PR TITLE
feat: enforce source metadata in HARD evidence

### DIFF
--- a/src/ingestion/postgres_repository.py
+++ b/src/ingestion/postgres_repository.py
@@ -50,6 +50,18 @@ class PostgresRepository:
                 f"{context} requires non-empty evidence_hard (HARD evidence)"
             )
 
+        for index, item in enumerate(evidence_hard):
+            if not isinstance(item, Mapping):
+                raise ValueError(
+                    f"{context} evidence_hard[{index}] must be an object with traceable metadata"
+                )
+
+            source = item.get("source")
+            if not isinstance(source, str) or source.strip() == "":
+                raise ValueError(
+                    f"{context} evidence_hard[{index}] requires non-empty source"
+                )
+
     def _connect(self) -> ConnectionProtocol:
         if self._connection_factory is not None:
             return self._connection_factory()


### PR DESCRIPTION
## Why
HARD evidence must be traceable to a concrete source so downstream macro→sector→stock decisions remain auditable.

## What
- strengthen `PostgresRepository._require_hard_evidence` validation
- require each `evidence_hard` entry to be an object
- require non-empty `source` on each HARD evidence item
- add unit tests for malformed HARD evidence payloads

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- result: `72 passed`
