### PR TITLE
feat: surface HARD/SOFT evidence coverage in dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -44,14 +44,20 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         attribution_total = to_int(attribution_summary.get("total", 0))
         top_category = str(attribution_summary.get("top_category", "n/a"))
         top_count = to_int(attribution_summary.get("top_count", 0))
+        hard_evidence_coverage = attribution_summary.get("hard_evidence_coverage")
+        soft_evidence_coverage = attribution_summary.get("soft_evidence_coverage")
     else:
         attribution_total = 0
         top_category = "n/a"
         top_count = 0
+        hard_evidence_coverage = None
+        soft_evidence_coverage = None
 
     coverage_pct = "n/a" if not isinstance(realization_coverage, (int, float)) else f"{realization_coverage * 100:.1f}%"
     hit_rate_pct = "n/a" if not isinstance(hit_rate, (int, float)) else f"{hit_rate * 100:.1f}%"
     mae_pct = "n/a" if not isinstance(mae, (int, float)) else f"{mae * 100:.2f}%"
+    hard_evidence_pct = "n/a" if not isinstance(hard_evidence_coverage, (int, float)) else f"{hard_evidence_coverage * 100:.1f}%"
+    soft_evidence_pct = "n/a" if not isinstance(soft_evidence_coverage, (int, float)) else f"{soft_evidence_coverage * 100:.1f}%"
 
     return {
         "last_run_status": str(view.get("last_run_status", "no-data")),
@@ -67,6 +73,8 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         "attribution_total": attribution_total,
         "attribution_top_category": top_category,
         "attribution_top_count": top_count,
+        "hard_evidence_pct": hard_evidence_pct,
+        "soft_evidence_pct": soft_evidence_pct,
     }
 
 
@@ -88,7 +96,7 @@ def run_streamlit_app(dsn: str) -> None:
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 
-    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11 = st.columns(11)
+    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13 = st.columns(13)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
     c2.metric("Raw", cards["raw_events"])
     c3.metric("Canonical", cards["canonical_events"])
@@ -100,6 +108,8 @@ def run_streamlit_app(dsn: str) -> None:
     c9.metric("1M MAE", cards["mae_pct"])
     c10.metric("1M Attr", cards["attribution_total"])
     c11.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
+    c12.metric("HARD Evd", cards["hard_evidence_pct"])
+    c13.metric("SOFT Evd", cards["soft_evidence_pct"])
 
     recent_runs = view.get("recent_runs", [])
     if isinstance(recent_runs, list) and recent_runs:

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -30,6 +30,8 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "total": 7,
                 "top_category": "macro_miss",
                 "top_count": 3,
+                "hard_evidence_coverage": 0.86,
+                "soft_evidence_coverage": 0.57,
             },
             "recent_runs": [],
         }
@@ -46,3 +48,5 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["attribution_total"] == 7
     assert cards["attribution_top_category"] == "macro_miss"
     assert cards["attribution_top_count"] == 3
+    assert cards["hard_evidence_pct"] == "86.0%"
+    assert cards["soft_evidence_pct"] == "57.0%"

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -41,6 +41,13 @@ class FakeDashboardRepo:
             },
         ]
 
+    def read_forecast_error_attributions(self, horizon="1M", limit=200):
+        return [
+            {"category": "macro_miss", "evidence_hard": [{"source": "FRED"}], "evidence_soft": [{"note": "regime"}]},
+            {"category": "macro_miss", "evidence_hard": [{"source": "ECOS"}], "evidence_soft": []},
+            {"category": "valuation_miss", "evidence_hard": [], "evidence_soft": [{"note": "narrative"}]},
+        ]
+
 
 def test_dashboard_service_builds_operator_view_model():
     view = build_dashboard_view(FakeDashboardRepo())
@@ -55,4 +62,6 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["attribution_summary"]["top_count"] == 2
     assert len(view["attribution_summary"]["top_categories"]) == 2
     assert view["attribution_summary"]["top_categories"][0]["mean_abs_contribution"] == 0.021
+    assert view["attribution_summary"]["hard_evidence_coverage"] == 2 / 3
+    assert view["attribution_summary"]["soft_evidence_coverage"] == 2 / 3
     assert len(view["recent_runs"]) == 2


### PR DESCRIPTION
## Why
- Improve macro→sector→stock evidence traceability quality in operator dashboard.
- Make it immediately visible how often forecast-error attributions include HARD vs SOFT evidence.

## What
- Added  and  to dashboard attribution summary.
- Compute coverage from  when available, while keeping existing category aggregation intact.
- Exposed two new dashboard cards:  and .
- Added/updated tests for service and UI card formatting.

## Validation
- ........................................................................ [100%]
72 passed in 0.19s
- Result: 
