### PR TITLE
Add no-evidence attribution gap coverage to dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -46,18 +46,23 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         top_count = to_int(attribution_summary.get("top_count", 0))
         hard_evidence_coverage = attribution_summary.get("hard_evidence_coverage")
         soft_evidence_coverage = attribution_summary.get("soft_evidence_coverage")
+        evidence_gap_count = to_int(attribution_summary.get("evidence_gap_count", 0))
+        evidence_gap_coverage = attribution_summary.get("evidence_gap_coverage")
     else:
         attribution_total = 0
         top_category = "n/a"
         top_count = 0
         hard_evidence_coverage = None
         soft_evidence_coverage = None
+        evidence_gap_count = 0
+        evidence_gap_coverage = None
 
     coverage_pct = "n/a" if not isinstance(realization_coverage, (int, float)) else f"{realization_coverage * 100:.1f}%"
     hit_rate_pct = "n/a" if not isinstance(hit_rate, (int, float)) else f"{hit_rate * 100:.1f}%"
     mae_pct = "n/a" if not isinstance(mae, (int, float)) else f"{mae * 100:.2f}%"
     hard_evidence_pct = "n/a" if not isinstance(hard_evidence_coverage, (int, float)) else f"{hard_evidence_coverage * 100:.1f}%"
     soft_evidence_pct = "n/a" if not isinstance(soft_evidence_coverage, (int, float)) else f"{soft_evidence_coverage * 100:.1f}%"
+    evidence_gap_pct = "n/a" if not isinstance(evidence_gap_coverage, (int, float)) else f"{evidence_gap_coverage * 100:.1f}%"
 
     return {
         "last_run_status": str(view.get("last_run_status", "no-data")),
@@ -75,6 +80,8 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         "attribution_top_count": top_count,
         "hard_evidence_pct": hard_evidence_pct,
         "soft_evidence_pct": soft_evidence_pct,
+        "evidence_gap_count": evidence_gap_count,
+        "evidence_gap_pct": evidence_gap_pct,
     }
 
 
@@ -96,7 +103,7 @@ def run_streamlit_app(dsn: str) -> None:
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 
-    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13 = st.columns(13)
+    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14 = st.columns(14)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
     c2.metric("Raw", cards["raw_events"])
     c3.metric("Canonical", cards["canonical_events"])
@@ -110,6 +117,7 @@ def run_streamlit_app(dsn: str) -> None:
     c11.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
     c12.metric("HARD Evd", cards["hard_evidence_pct"])
     c13.metric("SOFT Evd", cards["soft_evidence_pct"])
+    c14.metric("No-Evd Attr", cards["evidence_gap_count"], cards["evidence_gap_pct"])
 
     recent_runs = view.get("recent_runs", [])
     if isinstance(recent_runs, list) and recent_runs:

--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -38,6 +38,8 @@ def build_dashboard_view(
         "top_categories": [],
         "hard_evidence_coverage": None,
         "soft_evidence_coverage": None,
+        "evidence_gap_count": 0,
+        "evidence_gap_coverage": None,
     }
     if hasattr(repository, "read_forecast_error_category_stats"):
         category_stats = repository.read_forecast_error_category_stats(horizon="1M", limit=5)
@@ -50,6 +52,8 @@ def build_dashboard_view(
                 "top_categories": category_stats,
                 "hard_evidence_coverage": None,
                 "soft_evidence_coverage": None,
+                "evidence_gap_count": 0,
+                "evidence_gap_coverage": None,
             }
 
     if hasattr(repository, "read_forecast_error_attributions"):
@@ -77,19 +81,27 @@ def build_dashboard_view(
 
             hard_count = 0
             soft_count = 0
+            evidence_gap_count = 0
             valid_rows = 0
             for row in attribution_rows:
                 if not isinstance(row, dict):
                     continue
                 valid_rows += 1
-                if _count_non_empty_evidence(row.get("evidence_hard")):
+                has_hard = _count_non_empty_evidence(row.get("evidence_hard"))
+                has_soft = _count_non_empty_evidence(row.get("evidence_soft"))
+                if has_hard:
                     hard_count += 1
-                if _count_non_empty_evidence(row.get("evidence_soft")):
+                if has_soft:
                     soft_count += 1
+                if not has_hard and not has_soft:
+                    evidence_gap_count += 1
 
             if valid_rows > 0:
+                attribution_summary["total"] = valid_rows
                 attribution_summary["hard_evidence_coverage"] = hard_count / valid_rows
                 attribution_summary["soft_evidence_coverage"] = soft_count / valid_rows
+                attribution_summary["evidence_gap_count"] = evidence_gap_count
+                attribution_summary["evidence_gap_coverage"] = evidence_gap_count / valid_rows
 
     if recent_runs:
         latest = recent_runs[0]

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -32,6 +32,8 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "top_count": 3,
                 "hard_evidence_coverage": 0.86,
                 "soft_evidence_coverage": 0.57,
+                "evidence_gap_count": 1,
+                "evidence_gap_coverage": 0.14,
             },
             "recent_runs": [],
         }
@@ -50,3 +52,5 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["attribution_top_count"] == 3
     assert cards["hard_evidence_pct"] == "86.0%"
     assert cards["soft_evidence_pct"] == "57.0%"
+    assert cards["evidence_gap_count"] == 1
+    assert cards["evidence_gap_pct"] == "14.0%"

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -46,6 +46,7 @@ class FakeDashboardRepo:
             {"category": "macro_miss", "evidence_hard": [{"source": "FRED"}], "evidence_soft": [{"note": "regime"}]},
             {"category": "macro_miss", "evidence_hard": [{"source": "ECOS"}], "evidence_soft": []},
             {"category": "valuation_miss", "evidence_hard": [], "evidence_soft": [{"note": "narrative"}]},
+            {"category": "unknown", "evidence_hard": [], "evidence_soft": []},
         ]
 
 
@@ -57,11 +58,13 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["counters"]["raw_events"] == 100
     assert view["learning_metrics"]["horizon"] == "1M"
     assert view["learning_metrics"]["hit_rate"] == 0.58
-    assert view["attribution_summary"]["total"] == 3
+    assert view["attribution_summary"]["total"] == 4
     assert view["attribution_summary"]["top_category"] == "macro_miss"
     assert view["attribution_summary"]["top_count"] == 2
     assert len(view["attribution_summary"]["top_categories"]) == 2
     assert view["attribution_summary"]["top_categories"][0]["mean_abs_contribution"] == 0.021
-    assert view["attribution_summary"]["hard_evidence_coverage"] == 2 / 3
-    assert view["attribution_summary"]["soft_evidence_coverage"] == 2 / 3
+    assert view["attribution_summary"]["hard_evidence_coverage"] == 0.5
+    assert view["attribution_summary"]["soft_evidence_coverage"] == 0.5
+    assert view["attribution_summary"]["evidence_gap_count"] == 1
+    assert view["attribution_summary"]["evidence_gap_coverage"] == 0.25
     assert len(view["recent_runs"]) == 2


### PR DESCRIPTION
## Why
To improve evidence traceability quality, operators need an explicit signal when forecast-error attributions lack both HARD and SOFT evidence.

## What
- Added  and  to dashboard attribution summary.
- Updated dashboard cards to show  metric and percentage.
- Normalized attribution  to actual attribution-row count when row-level evidence is available.
- Extended smoke/service tests for new coverage metric.

## Validation
- ........................................................................ [100%]
72 passed in 0.19s (72 passed)
