### PR TITLE
Harden attribution evidence coverage for malformed string payloads

### DIFF
--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -19,8 +19,7 @@ def _count_non_empty_evidence(value: object) -> bool:
     if isinstance(value, list):
         return len(value) > 0
     if isinstance(value, str):
-        trimmed = value.strip()
-        return trimmed not in {"", "[]", "null", "None"}
+        return len(_parse_evidence_items(value)) > 0
     return value is not None
 
 


### PR DESCRIPTION
## Why
Attribution evidence coverage metrics could over-count malformed string payloads (for example: not-json) as valid evidence. That weakens HARD/SOFT traceability quality checks.

## What
- Tightened `_count_non_empty_evidence` to parse string evidence as JSON list and count only valid non-empty arrays.
- Added regression test to verify malformed string evidence is ignored while valid JSON-string arrays are still counted.

## Validation
- FRED_API_KEY= ECOS_API_KEY= pytest -q
- Result: 75 passed
