### PR TITLE
feat: show HARD evidence traceability coverage on dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -45,6 +45,9 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         top_category = str(attribution_summary.get("top_category", "n/a"))
         top_count = to_int(attribution_summary.get("top_count", 0))
         hard_evidence_coverage = attribution_summary.get("hard_evidence_coverage")
+        hard_evidence_traceability_coverage = attribution_summary.get(
+            "hard_evidence_traceability_coverage"
+        )
         soft_evidence_coverage = attribution_summary.get("soft_evidence_coverage")
         evidence_gap_count = to_int(attribution_summary.get("evidence_gap_count", 0))
         evidence_gap_coverage = attribution_summary.get("evidence_gap_coverage")
@@ -53,6 +56,7 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         top_category = "n/a"
         top_count = 0
         hard_evidence_coverage = None
+        hard_evidence_traceability_coverage = None
         soft_evidence_coverage = None
         evidence_gap_count = 0
         evidence_gap_coverage = None
@@ -61,6 +65,11 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
     hit_rate_pct = "n/a" if not isinstance(hit_rate, (int, float)) else f"{hit_rate * 100:.1f}%"
     mae_pct = "n/a" if not isinstance(mae, (int, float)) else f"{mae * 100:.2f}%"
     hard_evidence_pct = "n/a" if not isinstance(hard_evidence_coverage, (int, float)) else f"{hard_evidence_coverage * 100:.1f}%"
+    hard_evidence_traceability_pct = (
+        "n/a"
+        if not isinstance(hard_evidence_traceability_coverage, (int, float))
+        else f"{hard_evidence_traceability_coverage * 100:.1f}%"
+    )
     soft_evidence_pct = "n/a" if not isinstance(soft_evidence_coverage, (int, float)) else f"{soft_evidence_coverage * 100:.1f}%"
     evidence_gap_pct = "n/a" if not isinstance(evidence_gap_coverage, (int, float)) else f"{evidence_gap_coverage * 100:.1f}%"
 
@@ -79,6 +88,7 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         "attribution_top_category": top_category,
         "attribution_top_count": top_count,
         "hard_evidence_pct": hard_evidence_pct,
+        "hard_evidence_traceability_pct": hard_evidence_traceability_pct,
         "soft_evidence_pct": soft_evidence_pct,
         "evidence_gap_count": evidence_gap_count,
         "evidence_gap_pct": evidence_gap_pct,
@@ -103,7 +113,7 @@ def run_streamlit_app(dsn: str) -> None:
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 
-    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14 = st.columns(14)
+    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15 = st.columns(15)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
     c2.metric("Raw", cards["raw_events"])
     c3.metric("Canonical", cards["canonical_events"])
@@ -116,8 +126,9 @@ def run_streamlit_app(dsn: str) -> None:
     c10.metric("1M Attr", cards["attribution_total"])
     c11.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
     c12.metric("HARD Evd", cards["hard_evidence_pct"])
-    c13.metric("SOFT Evd", cards["soft_evidence_pct"])
-    c14.metric("No-Evd Attr", cards["evidence_gap_count"], cards["evidence_gap_pct"])
+    c13.metric("HARD Trace", cards["hard_evidence_traceability_pct"])
+    c14.metric("SOFT Evd", cards["soft_evidence_pct"])
+    c15.metric("No-Evd Attr", cards["evidence_gap_count"], cards["evidence_gap_pct"])
 
     recent_runs = view.get("recent_runs", [])
     if isinstance(recent_runs, list) and recent_runs:

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -31,6 +31,7 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "top_category": "macro_miss",
                 "top_count": 3,
                 "hard_evidence_coverage": 0.86,
+                "hard_evidence_traceability_coverage": 0.71,
                 "soft_evidence_coverage": 0.57,
                 "evidence_gap_count": 1,
                 "evidence_gap_coverage": 0.14,
@@ -51,6 +52,7 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["attribution_top_category"] == "macro_miss"
     assert cards["attribution_top_count"] == 3
     assert cards["hard_evidence_pct"] == "86.0%"
+    assert cards["hard_evidence_traceability_pct"] == "71.0%"
     assert cards["soft_evidence_pct"] == "57.0%"
     assert cards["evidence_gap_count"] == 1
     assert cards["evidence_gap_pct"] == "14.0%"


### PR DESCRIPTION
## Why
- Ground rules require HARD evidence to remain traceable, not just present.
- Dashboard already computes `hard_evidence_traceability_coverage` but did not expose it in operator cards.

## What
- Add `hard_evidence_traceability_pct` to `build_operator_cards`.
- Render new `HARD Trace` metric card in Streamlit dashboard.
- Extend dashboard smoke test to validate the new metric formatting.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `75 passed`
