### PR TITLE
Add HARD evidence tier to normalized macro series points

### DIFF
--- a/src/research/contracts.py
+++ b/src/research/contracts.py
@@ -1,5 +1,9 @@
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
+
+
+EvidenceTier = Literal["HARD", "SOFT"]
 
 
 @dataclass(frozen=True)
@@ -11,3 +15,4 @@ class NormalizedSeriesPoint:
     available_at: datetime
     value: float
     lineage_id: str
+    evidence_tier: EvidenceTier = "HARD"

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -23,6 +23,7 @@ def test_normalize_fred_payload_maps_observations_sorted():
     assert len(points) == 2
     assert [p.value for p in points] == [3.1, 3.2]
     assert points[0].metric_key == "CPIAUCSL"
+    assert all(p.evidence_tier == "HARD" for p in points)
 
 
 def test_normalize_ecos_payload_skips_malformed_rows():


### PR DESCRIPTION
## Why
To strengthen macro analysis evidence traceability and keep HARD/SOFT separation explicit from normalization output onward.

## What
- Added  type () in research contracts.
- Extended  with  defaulting to  for official macro series payloads.
- Added normalization test assertion to verify HARD tier tagging.

## Validation
- ........................................................................ [ 96%]
...                                                                      [100%]
75 passed in 0.22s (75 passed)
