### PR TITLE
Tighten HARD evidence traceability checks in dashboard

### DIFF
--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -43,8 +43,16 @@ def _has_traceable_hard_evidence(value: object) -> bool:
     for item in _parse_evidence_items(value):
         if not isinstance(item, dict):
             continue
+
         source = str(item.get("source", "")).strip()
-        if source:
+        metric = str(item.get("metric", "") or item.get("metric_key", "")).strip()
+        entity_id = str(item.get("entity_id", "")).strip()
+        as_of = str(item.get("as_of", "")).strip()
+        available_at = str(item.get("available_at", "")).strip()
+        lineage_id = str(item.get("lineage_id", "")).strip()
+
+        has_reference = bool(metric or entity_id or as_of or available_at or lineage_id)
+        if source and has_reference:
             return True
     return False
 

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -64,7 +64,7 @@ def test_dashboard_service_builds_operator_view_model():
     assert len(view["attribution_summary"]["top_categories"]) == 2
     assert view["attribution_summary"]["top_categories"][0]["mean_abs_contribution"] == 0.021
     assert view["attribution_summary"]["hard_evidence_coverage"] == 0.5
-    assert view["attribution_summary"]["hard_evidence_traceability_coverage"] == 0.25
+    assert view["attribution_summary"]["hard_evidence_traceability_coverage"] == 0.0
     assert view["attribution_summary"]["soft_evidence_coverage"] == 0.5
     assert view["attribution_summary"]["evidence_gap_count"] == 1
     assert view["attribution_summary"]["evidence_gap_coverage"] == 0.25


### PR DESCRIPTION
## Why
Current dashboard counts HARD evidence as traceable when only  exists, which can overstate evidence traceability quality.

## What
- Tightened  logic to require:
  - non-empty , and
  - at least one reference field (/////).
- Updated dashboard service tests to reflect stricter traceability definition.

## Validation
- ........................................................................ [ 96%]
...                                                                      [100%]
75 passed in 0.20s (75 passed)
