### PR TITLE
Add signed forecast error to 1M learning metrics dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -32,12 +32,14 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         realization_coverage = learning.get("realization_coverage")
         hit_rate = learning.get("hit_rate")
         mae = learning.get("mean_abs_forecast_error")
+        signed_error = learning.get("mean_signed_forecast_error")
     else:
         forecast_count = 0
         realized_count = 0
         realization_coverage = None
         hit_rate = None
         mae = None
+        signed_error = None
 
     attribution_summary = view.get("attribution_summary", {})
     if isinstance(attribution_summary, Mapping):
@@ -64,6 +66,9 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
     coverage_pct = "n/a" if not isinstance(realization_coverage, (int, float)) else f"{realization_coverage * 100:.1f}%"
     hit_rate_pct = "n/a" if not isinstance(hit_rate, (int, float)) else f"{hit_rate * 100:.1f}%"
     mae_pct = "n/a" if not isinstance(mae, (int, float)) else f"{mae * 100:.2f}%"
+    signed_error_pct = (
+        "n/a" if not isinstance(signed_error, (int, float)) else f"{signed_error * 100:.2f}%"
+    )
     hard_evidence_pct = "n/a" if not isinstance(hard_evidence_coverage, (int, float)) else f"{hard_evidence_coverage * 100:.1f}%"
     hard_evidence_traceability_pct = (
         "n/a"
@@ -84,6 +89,7 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         "coverage_pct": coverage_pct,
         "hit_rate_pct": hit_rate_pct,
         "mae_pct": mae_pct,
+        "signed_error_pct": signed_error_pct,
         "attribution_total": attribution_total,
         "attribution_top_category": top_category,
         "attribution_top_count": top_count,
@@ -113,7 +119,7 @@ def run_streamlit_app(dsn: str) -> None:
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 
-    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15 = st.columns(15)
+    c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16 = st.columns(16)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
     c2.metric("Raw", cards["raw_events"])
     c3.metric("Canonical", cards["canonical_events"])
@@ -123,12 +129,13 @@ def run_streamlit_app(dsn: str) -> None:
     c7.metric("1M Coverage", cards["coverage_pct"])
     c8.metric("1M Hit Rate", cards["hit_rate_pct"])
     c9.metric("1M MAE", cards["mae_pct"])
-    c10.metric("1M Attr", cards["attribution_total"])
-    c11.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
-    c12.metric("HARD Evd", cards["hard_evidence_pct"])
-    c13.metric("HARD Trace", cards["hard_evidence_traceability_pct"])
-    c14.metric("SOFT Evd", cards["soft_evidence_pct"])
-    c15.metric("No-Evd Attr", cards["evidence_gap_count"], cards["evidence_gap_pct"])
+    c10.metric("1M Bias", cards["signed_error_pct"])
+    c11.metric("1M Attr", cards["attribution_total"])
+    c12.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
+    c13.metric("HARD Evd", cards["hard_evidence_pct"])
+    c14.metric("HARD Trace", cards["hard_evidence_traceability_pct"])
+    c15.metric("SOFT Evd", cards["soft_evidence_pct"])
+    c16.metric("No-Evd Attr", cards["evidence_gap_count"], cards["evidence_gap_pct"])
 
     recent_runs = view.get("recent_runs", [])
     if isinstance(recent_runs, list) and recent_runs:

--- a/src/ingestion/postgres_repository.py
+++ b/src/ingestion/postgres_repository.py
@@ -668,14 +668,15 @@ class PostgresRepository:
             SELECT
                 COUNT(*) AS realized_count,
                 AVG(CASE WHEN rr.hit THEN 1.0 ELSE 0.0 END) AS hit_rate,
-                AVG(ABS(rr.forecast_error)) AS mean_abs_forecast_error
+                AVG(ABS(rr.forecast_error)) AS mean_abs_forecast_error,
+                AVG(rr.forecast_error) AS mean_signed_forecast_error
             FROM realization_records rr
             JOIN forecast_records fr ON fr.id = rr.forecast_id
             WHERE fr.horizon = %s
             """,
             (horizon,),
         )
-        row = cursor.fetchone() or (0, None, None)
+        row = cursor.fetchone() or (0, None, None, None)
 
         cursor.close()
         conn.close()
@@ -716,6 +717,7 @@ class PostgresRepository:
             "realization_coverage": realization_coverage,
             "hit_rate": to_float_or_none(row[1]),
             "mean_abs_forecast_error": to_float_or_none(row[2]),
+            "mean_signed_forecast_error": to_float_or_none(row[3]),
         }
 
     def write_macro_series_points(self, points: list[NormalizedSeriesPoint]) -> int:

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -25,6 +25,7 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "realization_coverage": 0.4,
                 "hit_rate": 0.6,
                 "mean_abs_forecast_error": 0.025,
+                "mean_signed_forecast_error": -0.007,
             },
             "attribution_summary": {
                 "total": 7,
@@ -48,6 +49,7 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["coverage_pct"] == "40.0%"
     assert cards["hit_rate_pct"] == "60.0%"
     assert cards["mae_pct"] == "2.50%"
+    assert cards["signed_error_pct"] == "-0.70%"
     assert cards["attribution_total"] == 7
     assert cards["attribution_top_category"] == "macro_miss"
     assert cards["attribution_top_count"] == 3

--- a/tests/test_postgres_repository.py
+++ b/tests/test_postgres_repository.py
@@ -99,7 +99,7 @@ def test_postgres_repository_writes_pipeline_rows_and_reads_counters():
 
 
 def test_postgres_repository_reads_learning_metrics_for_1m_horizon():
-    cursor = FakeCursor(fetch_one_rows=[(20,), (12, 0.5833, 0.0315)])
+    cursor = FakeCursor(fetch_one_rows=[(20,), (12, 0.5833, 0.0315, -0.0042)])
     conn = FakeConnection(cursor)
     repo = PostgresRepository(connection_factory=lambda: conn)
 
@@ -119,6 +119,7 @@ def test_postgres_repository_reads_learning_metrics_for_1m_horizon():
     assert metrics["realization_coverage"] == 0.6
     assert metrics["hit_rate"] == 0.5833
     assert metrics["mean_abs_forecast_error"] == 0.0315
+    assert metrics["mean_signed_forecast_error"] == -0.0042
 
 
 def test_postgres_repository_writes_investment_thesis_and_returns_id():


### PR DESCRIPTION
## Why
We tracked hit rate and absolute forecast error, but lacked directional bias visibility (systematic over/under-forecasting), which weakens forecast-error learning automation.

## What
- Extend `read_learning_metrics` to compute and return `mean_signed_forecast_error` from realization records.
- Surface the signed error in dashboard cards as `signed_error_pct` and add a `1M Bias` metric tile.
- Update repository and dashboard tests to cover signed error propagation/formatting.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: 75 passed
