### PR TITLE
Guard dashboard cards against malformed numeric strings

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -12,7 +12,10 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         if isinstance(value, float):
             return int(value)
         if isinstance(value, str):
-            return int(value)
+            try:
+                return int(value)
+            except ValueError:
+                return 0
         return 0
 
     counters = view.get("counters", {})

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -58,3 +58,33 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["soft_evidence_pct"] == "57.0%"
     assert cards["evidence_gap_count"] == 1
     assert cards["evidence_gap_pct"] == "14.0%"
+
+
+def test_dashboard_app_handles_non_numeric_counter_strings_safely():
+    cards = dashboard_app.build_operator_cards(
+        {
+            "counters": {
+                "raw_events": "n/a",
+                "canonical_events": "",
+                "quarantine_events": "unknown",
+            },
+            "learning_metrics": {
+                "forecast_count": "-",
+                "realized_count": "none",
+            },
+            "attribution_summary": {
+                "total": "not-a-number",
+                "top_count": "?",
+                "evidence_gap_count": "",
+            },
+        }
+    )
+
+    assert cards["raw_events"] == 0
+    assert cards["canonical_events"] == 0
+    assert cards["quarantine_events"] == 0
+    assert cards["forecast_count"] == 0
+    assert cards["realized_count"] == 0
+    assert cards["attribution_total"] == 0
+    assert cards["attribution_top_count"] == 0
+    assert cards["evidence_gap_count"] == 0


### PR DESCRIPTION
## Why
Production dashboard cards cast several fields with int(value) directly. If upstream data has malformed numeric strings (for example "n/a"), Streamlit can crash and show a user-facing error.

## What
- Added safe string-to-int conversion in build_operator_cards (returns 0 on ValueError).
- Added regression test covering malformed string counters and metrics.

## Validation
- FRED_API_KEY= ECOS_API_KEY= pytest -q (77 passed)
