### PR TITLE
fix: prevent false-zero KPI rendering on malformed dashboard metrics

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 
 
 def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
-    def to_int(value: object) -> int:
+    def to_int(value: object) -> int | None:
         if isinstance(value, bool):
             return int(value)
         if isinstance(value, int):
@@ -18,8 +18,8 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
                 try:
                     return int(float(value))
                 except ValueError:
-                    return 0
-        return 0
+                    return None
+        return None
 
     def to_float(value: object) -> float | None:
         if isinstance(value, bool):
@@ -104,22 +104,22 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
     return {
         "last_run_status": str(view.get("last_run_status", "no-data")),
         "last_run_time": str(view.get("last_run_time", "")),
-        "raw_events": raw_events,
-        "canonical_events": canonical_events,
-        "quarantine_events": quarantine_events,
-        "forecast_count": forecast_count,
-        "realized_count": realized_count,
+        "raw_events": "n/a" if raw_events is None else raw_events,
+        "canonical_events": "n/a" if canonical_events is None else canonical_events,
+        "quarantine_events": "n/a" if quarantine_events is None else quarantine_events,
+        "forecast_count": "n/a" if forecast_count is None else forecast_count,
+        "realized_count": "n/a" if realized_count is None else realized_count,
         "coverage_pct": coverage_pct,
         "hit_rate_pct": hit_rate_pct,
         "mae_pct": mae_pct,
         "signed_error_pct": signed_error_pct,
-        "attribution_total": attribution_total,
+        "attribution_total": "n/a" if attribution_total is None else attribution_total,
         "attribution_top_category": top_category,
-        "attribution_top_count": top_count,
+        "attribution_top_count": "n/a" if top_count is None else top_count,
         "hard_evidence_pct": hard_evidence_pct,
         "hard_evidence_traceability_pct": hard_evidence_traceability_pct,
         "soft_evidence_pct": soft_evidence_pct,
-        "evidence_gap_count": evidence_gap_count,
+        "evidence_gap_count": "n/a" if evidence_gap_count is None else evidence_gap_count,
         "evidence_gap_pct": evidence_gap_pct,
     }
 

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -60,7 +60,7 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["evidence_gap_pct"] == "14.0%"
 
 
-def test_dashboard_app_handles_non_numeric_counter_strings_safely():
+def test_dashboard_app_treats_malformed_count_metrics_as_unknown():
     cards = dashboard_app.build_operator_cards(
         {
             "counters": {
@@ -80,14 +80,14 @@ def test_dashboard_app_handles_non_numeric_counter_strings_safely():
         }
     )
 
-    assert cards["raw_events"] == 0
-    assert cards["canonical_events"] == 0
-    assert cards["quarantine_events"] == 0
-    assert cards["forecast_count"] == 0
-    assert cards["realized_count"] == 0
-    assert cards["attribution_total"] == 0
-    assert cards["attribution_top_count"] == 0
-    assert cards["evidence_gap_count"] == 0
+    assert cards["raw_events"] == "n/a"
+    assert cards["canonical_events"] == "n/a"
+    assert cards["quarantine_events"] == "n/a"
+    assert cards["forecast_count"] == "n/a"
+    assert cards["realized_count"] == "n/a"
+    assert cards["attribution_total"] == "n/a"
+    assert cards["attribution_top_count"] == "n/a"
+    assert cards["evidence_gap_count"] == "n/a"
 
 
 def test_dashboard_app_parses_numeric_strings_for_percent_metrics():


### PR DESCRIPTION
## Why
Malformed/non-numeric KPI payloads in the dashboard were being coerced to , which can look like a real metric value and mislead operators.

## What
- Change operator card integer parsing to return  for malformed values instead of forcing 
- Render malformed count KPIs as  (unknown) for:
  - raw/canonical/quarantine counters
  - forecast/realized counts
  - attribution total/top count/evidence gap count
- Keep valid numeric strings and numeric values working as before
- Update dashboard smoke test expectations to assert unknown handling

## Validation
- ........................................................................ [ 92%]
......                                                                   [100%]
78 passed in 0.20s
- Result: 78 passed
