### PR TITLE
Fix #46: do not coerce malformed dashboard KPI values to zero

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -3,125 +3,150 @@ import importlib
 from collections.abc import Mapping
 
 
+PLACEHOLDER_STRINGS = {"", "-", "n/a", "na", "none", "null", "unknown"}
+CRITICAL_METRIC_KEYS = {
+    "raw_events",
+    "canonical_events",
+    "quarantine_events",
+    "forecast_count",
+    "realized_count",
+    "coverage_pct",
+    "hit_rate_pct",
+    "attribution_total",
+    "hard_evidence_pct",
+    "hard_evidence_traceability_pct",
+    "evidence_gap_count",
+}
+
+
+def _is_placeholder(value: object) -> bool:
+    return isinstance(value, str) and value.strip().lower() in PLACEHOLDER_STRINGS
+
+
+def _metric(value: object, status: str = "ok", reason: str | None = None) -> dict[str, object]:
+    return {"value": value, "status": status, "reason": reason}
+
+
 def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
-    def to_int(value: object) -> int | None:
+    def to_int_metric(value: object) -> dict[str, object]:
+        if value is None or _is_placeholder(value):
+            return _metric("n/a", status="unknown", reason="missing_or_placeholder")
         if isinstance(value, bool):
-            return int(value)
+            return _metric(int(value))
         if isinstance(value, int):
-            return value
+            return _metric(value)
         if isinstance(value, float):
-            return int(value)
+            return _metric(int(value))
         if isinstance(value, str):
             try:
-                return int(value)
+                return _metric(int(value))
             except ValueError:
                 try:
-                    return int(float(value))
+                    return _metric(int(float(value)))
                 except ValueError:
-                    return None
-        return None
+                    return _metric("n/a", status="error", reason="invalid_numeric")
+        return _metric("n/a", status="error", reason="unsupported_type")
 
-    def to_float(value: object) -> float | None:
+    def to_pct_metric(value: object, precision: int) -> dict[str, object]:
+        if value is None or _is_placeholder(value):
+            return _metric("n/a", status="unknown", reason="missing_or_placeholder")
         if isinstance(value, bool):
-            return float(int(value))
-        if isinstance(value, (int, float)):
-            return float(value)
-        if isinstance(value, str):
+            raw = float(int(value))
+        elif isinstance(value, (int, float)):
+            raw = float(value)
+        elif isinstance(value, str):
             try:
-                return float(value)
+                raw = float(value)
             except ValueError:
-                return None
-        return None
+                return _metric("n/a", status="error", reason="invalid_numeric")
+        else:
+            return _metric("n/a", status="error", reason="unsupported_type")
+        return _metric(f"{raw * 100:.{precision}f}%")
 
     counters = view.get("counters", {})
     if isinstance(counters, Mapping):
-        raw_events = to_int(counters.get("raw_events", 0))
-        canonical_events = to_int(counters.get("canonical_events", 0))
-        quarantine_events = to_int(counters.get("quarantine_events", 0))
+        raw_events = to_int_metric(counters.get("raw_events"))
+        canonical_events = to_int_metric(counters.get("canonical_events"))
+        quarantine_events = to_int_metric(counters.get("quarantine_events"))
     else:
-        raw_events = 0
-        canonical_events = 0
-        quarantine_events = 0
+        raw_events = _metric("n/a", status="unknown", reason="missing_block")
+        canonical_events = _metric("n/a", status="unknown", reason="missing_block")
+        quarantine_events = _metric("n/a", status="unknown", reason="missing_block")
 
     learning = view.get("learning_metrics", {})
     if isinstance(learning, Mapping):
-        forecast_count = to_int(learning.get("forecast_count", 0))
-        realized_count = to_int(learning.get("realized_count", 0))
-        realization_coverage = learning.get("realization_coverage")
-        hit_rate = learning.get("hit_rate")
-        mae = learning.get("mean_abs_forecast_error")
-        signed_error = learning.get("mean_signed_forecast_error")
+        forecast_count = to_int_metric(learning.get("forecast_count"))
+        realized_count = to_int_metric(learning.get("realized_count"))
+        coverage_pct = to_pct_metric(learning.get("realization_coverage"), precision=1)
+        hit_rate_pct = to_pct_metric(learning.get("hit_rate"), precision=1)
+        mae_pct = to_pct_metric(learning.get("mean_abs_forecast_error"), precision=2)
+        signed_error_pct = to_pct_metric(learning.get("mean_signed_forecast_error"), precision=2)
     else:
-        forecast_count = 0
-        realized_count = 0
-        realization_coverage = None
-        hit_rate = None
-        mae = None
-        signed_error = None
+        forecast_count = _metric("n/a", status="unknown", reason="missing_block")
+        realized_count = _metric("n/a", status="unknown", reason="missing_block")
+        coverage_pct = _metric("n/a", status="unknown", reason="missing_block")
+        hit_rate_pct = _metric("n/a", status="unknown", reason="missing_block")
+        mae_pct = _metric("n/a", status="unknown", reason="missing_block")
+        signed_error_pct = _metric("n/a", status="unknown", reason="missing_block")
 
     attribution_summary = view.get("attribution_summary", {})
     if isinstance(attribution_summary, Mapping):
-        attribution_total = to_int(attribution_summary.get("total", 0))
-        top_category = str(attribution_summary.get("top_category", "n/a"))
-        top_count = to_int(attribution_summary.get("top_count", 0))
-        hard_evidence_coverage = attribution_summary.get("hard_evidence_coverage")
-        hard_evidence_traceability_coverage = attribution_summary.get(
-            "hard_evidence_traceability_coverage"
+        attribution_total = to_int_metric(attribution_summary.get("total"))
+        top_category = _metric(str(attribution_summary.get("top_category", "n/a")))
+        top_count = to_int_metric(attribution_summary.get("top_count"))
+        hard_evidence_pct = to_pct_metric(attribution_summary.get("hard_evidence_coverage"), precision=1)
+        hard_evidence_traceability_pct = to_pct_metric(
+            attribution_summary.get("hard_evidence_traceability_coverage"), precision=1
         )
-        soft_evidence_coverage = attribution_summary.get("soft_evidence_coverage")
-        evidence_gap_count = to_int(attribution_summary.get("evidence_gap_count", 0))
-        evidence_gap_coverage = attribution_summary.get("evidence_gap_coverage")
+        soft_evidence_pct = to_pct_metric(attribution_summary.get("soft_evidence_coverage"), precision=1)
+        evidence_gap_count = to_int_metric(attribution_summary.get("evidence_gap_count"))
+        evidence_gap_pct = to_pct_metric(attribution_summary.get("evidence_gap_coverage"), precision=1)
     else:
-        attribution_total = 0
-        top_category = "n/a"
-        top_count = 0
-        hard_evidence_coverage = None
-        hard_evidence_traceability_coverage = None
-        soft_evidence_coverage = None
-        evidence_gap_count = 0
-        evidence_gap_coverage = None
+        attribution_total = _metric("n/a", status="unknown", reason="missing_block")
+        top_category = _metric("n/a", status="unknown", reason="missing_block")
+        top_count = _metric("n/a", status="unknown", reason="missing_block")
+        hard_evidence_pct = _metric("n/a", status="unknown", reason="missing_block")
+        hard_evidence_traceability_pct = _metric("n/a", status="unknown", reason="missing_block")
+        soft_evidence_pct = _metric("n/a", status="unknown", reason="missing_block")
+        evidence_gap_count = _metric("n/a", status="unknown", reason="missing_block")
+        evidence_gap_pct = _metric("n/a", status="unknown", reason="missing_block")
 
-    realization_coverage_value = to_float(realization_coverage)
-    hit_rate_value = to_float(hit_rate)
-    mae_value = to_float(mae)
-    signed_error_value = to_float(signed_error)
-    hard_evidence_value = to_float(hard_evidence_coverage)
-    hard_evidence_traceability_value = to_float(hard_evidence_traceability_coverage)
-    soft_evidence_value = to_float(soft_evidence_coverage)
-    evidence_gap_value = to_float(evidence_gap_coverage)
-
-    coverage_pct = "n/a" if realization_coverage_value is None else f"{realization_coverage_value * 100:.1f}%"
-    hit_rate_pct = "n/a" if hit_rate_value is None else f"{hit_rate_value * 100:.1f}%"
-    mae_pct = "n/a" if mae_value is None else f"{mae_value * 100:.2f}%"
-    signed_error_pct = "n/a" if signed_error_value is None else f"{signed_error_value * 100:.2f}%"
-    hard_evidence_pct = "n/a" if hard_evidence_value is None else f"{hard_evidence_value * 100:.1f}%"
-    hard_evidence_traceability_pct = (
-        "n/a" if hard_evidence_traceability_value is None else f"{hard_evidence_traceability_value * 100:.1f}%"
-    )
-    soft_evidence_pct = "n/a" if soft_evidence_value is None else f"{soft_evidence_value * 100:.1f}%"
-    evidence_gap_pct = "n/a" if evidence_gap_value is None else f"{evidence_gap_value * 100:.1f}%"
-
-    return {
-        "last_run_status": str(view.get("last_run_status", "no-data")),
-        "last_run_time": str(view.get("last_run_time", "")),
-        "raw_events": "n/a" if raw_events is None else raw_events,
-        "canonical_events": "n/a" if canonical_events is None else canonical_events,
-        "quarantine_events": "n/a" if quarantine_events is None else quarantine_events,
-        "forecast_count": "n/a" if forecast_count is None else forecast_count,
-        "realized_count": "n/a" if realized_count is None else realized_count,
+    metrics = {
+        "raw_events": raw_events,
+        "canonical_events": canonical_events,
+        "quarantine_events": quarantine_events,
+        "forecast_count": forecast_count,
+        "realized_count": realized_count,
         "coverage_pct": coverage_pct,
         "hit_rate_pct": hit_rate_pct,
         "mae_pct": mae_pct,
         "signed_error_pct": signed_error_pct,
-        "attribution_total": "n/a" if attribution_total is None else attribution_total,
+        "attribution_total": attribution_total,
         "attribution_top_category": top_category,
-        "attribution_top_count": "n/a" if top_count is None else top_count,
+        "attribution_top_count": top_count,
         "hard_evidence_pct": hard_evidence_pct,
         "hard_evidence_traceability_pct": hard_evidence_traceability_pct,
         "soft_evidence_pct": soft_evidence_pct,
-        "evidence_gap_count": "n/a" if evidence_gap_count is None else evidence_gap_count,
+        "evidence_gap_count": evidence_gap_count,
         "evidence_gap_pct": evidence_gap_pct,
     }
+
+    critical_unknown_or_error = any(
+        metrics[key]["status"] in {"unknown", "error"} for key in CRITICAL_METRIC_KEYS
+    )
+
+    return {
+        "last_run_status": str(view.get("last_run_status", "no-data")),
+        "last_run_time": str(view.get("last_run_time", "")),
+        **{k: v["value"] for k, v in metrics.items()},
+        "metric_status": {k: {"status": v["status"], "reason": v["reason"]} for k, v in metrics.items()},
+        "has_critical_metric_alert": critical_unknown_or_error,
+    }
+
+
+def _metric_delta(cards: Mapping[str, object], key: str) -> str | None:
+    status = cards.get("metric_status", {}).get(key, {}).get("status")
+    return status if status in {"unknown", "error"} else None
 
 
 def load_dashboard_view(dsn: str) -> dict[str, object]:
@@ -142,22 +167,31 @@ def run_streamlit_app(dsn: str) -> None:
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 
+    if cards["has_critical_metric_alert"]:
+        st.warning(
+            "Some dashboard metrics are unavailable or malformed; verify data pipeline before acting."
+        )
+
     c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16 = st.columns(16)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
-    c2.metric("Raw", cards["raw_events"])
-    c3.metric("Canonical", cards["canonical_events"])
-    c4.metric("Quarantine", cards["quarantine_events"])
-    c5.metric("1M Forecasts", cards["forecast_count"])
-    c6.metric("1M Realized", cards["realized_count"])
-    c7.metric("1M Coverage", cards["coverage_pct"])
-    c8.metric("1M Hit Rate", cards["hit_rate_pct"])
-    c9.metric("1M MAE", cards["mae_pct"])
-    c10.metric("1M Bias", cards["signed_error_pct"])
-    c11.metric("1M Attr", cards["attribution_total"])
+    c2.metric("Raw", cards["raw_events"], _metric_delta(cards, "raw_events"))
+    c3.metric("Canonical", cards["canonical_events"], _metric_delta(cards, "canonical_events"))
+    c4.metric("Quarantine", cards["quarantine_events"], _metric_delta(cards, "quarantine_events"))
+    c5.metric("1M Forecasts", cards["forecast_count"], _metric_delta(cards, "forecast_count"))
+    c6.metric("1M Realized", cards["realized_count"], _metric_delta(cards, "realized_count"))
+    c7.metric("1M Coverage", cards["coverage_pct"], _metric_delta(cards, "coverage_pct"))
+    c8.metric("1M Hit Rate", cards["hit_rate_pct"], _metric_delta(cards, "hit_rate_pct"))
+    c9.metric("1M MAE", cards["mae_pct"], _metric_delta(cards, "mae_pct"))
+    c10.metric("1M Bias", cards["signed_error_pct"], _metric_delta(cards, "signed_error_pct"))
+    c11.metric("1M Attr", cards["attribution_total"], _metric_delta(cards, "attribution_total"))
     c12.metric("Top Attr", cards["attribution_top_category"], cards["attribution_top_count"])
-    c13.metric("HARD Evd", cards["hard_evidence_pct"])
-    c14.metric("HARD Trace", cards["hard_evidence_traceability_pct"])
-    c15.metric("SOFT Evd", cards["soft_evidence_pct"])
+    c13.metric("HARD Evd", cards["hard_evidence_pct"], _metric_delta(cards, "hard_evidence_pct"))
+    c14.metric(
+        "HARD Trace",
+        cards["hard_evidence_traceability_pct"],
+        _metric_delta(cards, "hard_evidence_traceability_pct"),
+    )
+    c15.metric("SOFT Evd", cards["soft_evidence_pct"], _metric_delta(cards, "soft_evidence_pct"))
     c16.metric("No-Evd Attr", cards["evidence_gap_count"], cards["evidence_gap_pct"])
 
     recent_runs = view.get("recent_runs", [])


### PR DESCRIPTION
## Why
Malformed/non-numeric KPI values were rendered as zero-like healthy values in the dashboard path, which can mask data quality incidents and violate evidence-first monitoring semantics.

## What
- Refactored KPI parsing in  to produce explicit per-metric status () instead of silent numeric coercion
- Preserved true numeric zero handling (, , ) as valid 
- Added  and warning banner trigger when critical metrics are unknown/error
- Added status deltas to key metric cards so unknown/error states are visible
- Expanded tests in  for malformed placeholders, invalid numerics, and true-zero behavior

## Validation
- ........................................................................ [ 91%]
.......                                                                  [100%]
79 passed in 0.21s
- Result: 

Closes #46