### PR TITLE
Add multi-horizon (1W/1M/3M) learning metrics panel

### DIFF
--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -27,6 +27,32 @@ def test_dashboard_app_builds_cards_from_view_model():
                 "mean_abs_forecast_error": 0.025,
                 "mean_signed_forecast_error": -0.007,
             },
+            "learning_metrics_by_horizon": {
+                "1W": {
+                    "horizon": "1W",
+                    "forecast_count": 5,
+                    "realized_count": 4,
+                    "realization_coverage": 0.8,
+                    "hit_rate": 0.5,
+                    "mean_abs_forecast_error": 0.01,
+                },
+                "1M": {
+                    "horizon": "1M",
+                    "forecast_count": 25,
+                    "realized_count": 10,
+                    "realization_coverage": 0.4,
+                    "hit_rate": 0.6,
+                    "mean_abs_forecast_error": 0.025,
+                },
+                "3M": {
+                    "horizon": "3M",
+                    "forecast_count": 12,
+                    "realized_count": 8,
+                    "realization_coverage": 0.67,
+                    "hit_rate": 0.58,
+                    "mean_abs_forecast_error": 0.03,
+                },
+            },
             "attribution_summary": {
                 "total": 7,
                 "top_category": "macro_miss",
@@ -59,6 +85,8 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["evidence_gap_count"] == 1
     assert cards["evidence_gap_pct"] == "14.0%"
     assert cards["has_critical_metric_alert"] is False
+    assert len(cards["learning_metrics_panel"]) == 3
+    assert cards["learning_metrics_panel"][0]["horizon"] == "1W"
 
 
 def test_dashboard_app_treats_malformed_count_metrics_as_unknown_or_error():

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -58,6 +58,9 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["counters"]["raw_events"] == 100
     assert view["learning_metrics"]["horizon"] == "1M"
     assert view["learning_metrics"]["hit_rate"] == 0.58
+    assert view["learning_metrics_by_horizon"]["1W"]["horizon"] == "1W"
+    assert view["learning_metrics_by_horizon"]["1M"]["horizon"] == "1M"
+    assert view["learning_metrics_by_horizon"]["3M"]["horizon"] == "3M"
     assert view["attribution_summary"]["total"] == 4
     assert view["attribution_summary"]["top_category"] == "macro_miss"
     assert view["attribution_summary"]["top_count"] == 2
@@ -90,6 +93,8 @@ def test_dashboard_service_falls_back_when_learning_tables_missing():
     assert view["learning_metrics"]["forecast_count"] == 0
     assert view["learning_metrics"]["realized_count"] == 0
     assert view["learning_metrics"]["hit_rate"] is None
+    assert view["learning_metrics_by_horizon"]["1W"]["forecast_count"] == 0
+    assert view["learning_metrics_by_horizon"]["3M"]["forecast_count"] == 0
     assert view["attribution_summary"]["total"] == 0
     assert view["attribution_summary"]["top_category"] == "n/a"
 
@@ -116,6 +121,7 @@ def test_dashboard_service_falls_back_when_core_dashboard_queries_fail():
     }
     assert view["learning_metrics"]["forecast_count"] == 0
     assert view["learning_metrics"]["realized_count"] == 0
+    assert view["learning_metrics_by_horizon"]["1M"]["forecast_count"] == 0
 
 
 class StringEvidenceRepo(FakeDashboardRepo):


### PR DESCRIPTION
## Why
Operator visibility was limited to 1M learning metrics, making short-term risk drift (1W) and thesis durability (3M) harder to monitor.

## What
- Extended dashboard view model to fetch learning metrics for 1W/1M/3M horizons.
- Kept backward compatibility by preserving the existing `learning_metrics` 1M payload.
- Added `learning_metrics_by_horizon` to the dashboard view model.
- Added a new Streamlit table panel: **Multi-horizon Learning Metrics**.
- Added/updated tests for service fallback behavior and app card rendering.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `79 passed`

## Notes
- HARD/SOFT evidence separation remains unchanged.
- No secrets or destructive operations included.
