### PR TITLE
Fix dashboard evidence coverage for object payloads

### DIFF
--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -16,9 +16,7 @@ class DashboardRepositoryProtocol(Protocol):
 
 
 def _count_non_empty_evidence(value: object) -> bool:
-    if isinstance(value, list):
-        return len(value) > 0
-    if isinstance(value, str):
+    if isinstance(value, (list, str, dict)):
         return len(_parse_evidence_items(value)) > 0
     return value is not None
 
@@ -26,14 +24,26 @@ def _count_non_empty_evidence(value: object) -> bool:
 def _parse_evidence_items(value: object) -> list[object]:
     if isinstance(value, list):
         return value
+    if isinstance(value, dict):
+        if not value:
+            return []
+        items = value.get("items")
+        if isinstance(items, list):
+            return items
+        return [value]
     if isinstance(value, str):
         trimmed = value.strip()
-        if trimmed in {"", "[]", "null", "None"}:
+        if trimmed in {"", "[]", "null", "None", "{}"}:
             return []
         try:
             parsed = json.loads(trimmed)
             if isinstance(parsed, list):
                 return parsed
+            if isinstance(parsed, dict):
+                items = parsed.get("items")
+                if isinstance(items, list):
+                    return items
+                return [parsed]
         except json.JSONDecodeError:
             return []
     return []


### PR DESCRIPTION
## Why
Dashboard attribution evidence coverage can be under/over-counted when evidence payloads arrive as JSON objects (not arrays), which causes inaccurate HARD/SOFT coverage cards and traceability signals.

## What
- Extended evidence parser to accept object payloads in addition to arrays/array-JSON strings.
- Added support for wrapped object payloads with .
- Treated empty dict payloads as empty evidence.
- Updated non-empty evidence counter to correctly handle dict payloads via the shared parser.
- Added regression tests for object payload parsing + coverage metrics.

## Validation
- ........................................................................ [ 90%]
........                                                                 [100%]
80 passed in 0.22s
- Result: 
