### PR TITLE
Add attribution evidence-gap drill-down to dashboard

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -234,6 +234,24 @@ def run_streamlit_app(dsn: str) -> None:
         st.subheader("Multi-horizon Learning Metrics")
         st.dataframe(learning_panel, use_container_width=True)
 
+    attribution_gap_rows = view.get("attribution_gap_rows", [])
+    if isinstance(attribution_gap_rows, list):
+        st.subheader("Attribution Evidence Gaps (1M)")
+        only_problematic = st.checkbox(
+            "Show only problematic rows", value=True, key="show_only_problematic_attribution_rows"
+        )
+        rows_to_show = attribution_gap_rows
+        if only_problematic:
+            rows_to_show = [
+                row
+                for row in attribution_gap_rows
+                if isinstance(row, dict) and row.get("evidence_gap_reason") != "none"
+            ]
+        if rows_to_show:
+            st.dataframe(rows_to_show, use_container_width=True)
+        else:
+            st.info("No attribution evidence gaps detected in recent 1M rows.")
+
     recent_runs = view.get("recent_runs", [])
     if isinstance(recent_runs, list) and recent_runs:
         st.subheader("Recent Runs")

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -78,6 +78,9 @@ def test_dashboard_service_builds_operator_view_model():
     assert view["attribution_summary"]["soft_evidence_coverage"] == 0.5
     assert view["attribution_summary"]["evidence_gap_count"] == 1
     assert view["attribution_summary"]["evidence_gap_coverage"] == 0.25
+    assert len(view["attribution_gap_rows"]) == 4
+    assert view["attribution_gap_rows"][0]["evidence_gap_reason"] == "hard_untraceable"
+    assert view["attribution_gap_rows"][-1]["evidence_gap_reason"] == "missing_hard_and_soft"
     assert len(view["recent_runs"]) == 2
 
 


### PR DESCRIPTION
## Why
Resolves #48 by making evidence gaps actionable in the operator dashboard instead of aggregate-only metrics.

## What
- Added derived  in  with deterministic gap classification:
  - 
  - 
  - 
- Added trace preview fields () without exposing full payload blobs.
- Added new Streamlit section **Attribution Evidence Gaps (1M)** with default filter for problematic rows.
- Extended service tests to validate gap-row emission and reason classification behavior.

## Validation
- ........................................................................ [ 87%]
..........                                                               [100%]
82 passed in 0.21s
- Result: 
