### PR TITLE
Add sample-size reliability guardrails for multi-horizon learning KPIs

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -65,7 +65,13 @@ Environment variables:
 - Dashboard shows:
   - last run status/time
   - raw/canonical/quarantine counters
+  - multi-horizon learning metrics with reliability guardrails (`insufficient` / `low_sample` / `reliable`)
   - recent run history
+- Reliability threshold env overrides:
+  - `LEARNING_RELIABILITY_MIN_REALIZED_1W` (default: `8`)
+  - `LEARNING_RELIABILITY_MIN_REALIZED_1M` (default: `12`)
+  - `LEARNING_RELIABILITY_MIN_REALIZED_3M` (default: `6`)
+  - `LEARNING_RELIABILITY_COVERAGE_FLOOR` (default: `0.4`)
 
 ### Streamlit Community Cloud Deployment
 


### PR DESCRIPTION
## Why
Operator dashboard showed 1W/1M/3M learning KPIs without explicit sample-size reliability semantics, which can lead to over-trusting sparse realized samples.

## What
- Added deterministic reliability classification in `src/ingestion/dashboard_service.py`:
  - `insufficient` when `realized_count < min_realized_required`
  - `low_sample` for transitional/sample-weak zone
  - `reliable` when sample and coverage checks pass
- Added per-horizon reliability metadata to dashboard view:
  - `reliability_state`, `reliability_reason`, `min_realized_required`, `observed_realized_count`, `coverage_floor`
- Added env-configurable thresholds with defaults:
  - `LEARNING_RELIABILITY_MIN_REALIZED_1W=8`
  - `LEARNING_RELIABILITY_MIN_REALIZED_1M=12`
  - `LEARNING_RELIABILITY_MIN_REALIZED_3M=6`
  - `LEARNING_RELIABILITY_COVERAGE_FLOOR=0.4`
- Updated Streamlit operator cards/panel to render reliability fields and warning semantics (`warn` when not reliable).
- Added primary horizon (1M) reliability warning trigger.
- Added/updated unit tests for boundary behavior and env overrides.
- Documented threshold operations in ingestion runbook.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `84 passed`
