### PR TITLE
Add operator-safe idempotent forecast capture workflow

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -58,6 +58,33 @@ Environment variables:
   - `read_latest_macro_analysis(limit)`
 - 저장 필드에는 `regime`, `confidence`, `base/bull/bear`, `policy_case`, `critic_case`, `reason_codes`, `risk_flags`, `triggers`, `narrative`, `model` 포함
 
+## Forecast Capture (operator-safe)
+
+Use CLI (no direct SQL) to create/update a forecast record with schema validation and idempotency (`thesis_id + horizon + as_of`).
+
+Example:
+
+```bash
+python3 -m src.ingestion.cli forecast-record-create \
+  --thesis-id thesis-aapl-2026q1 \
+  --horizon 1M \
+  --expected-return-low 0.03 \
+  --expected-return-high 0.09 \
+  --expected-volatility 0.20 \
+  --expected-drawdown 0.12 \
+  --confidence 0.68 \
+  --key-drivers-json '["macro:disinflation","sector:semis"]' \
+  --evidence-hard-json '[{"source":"fred","metric":"CPI","as_of":"2026-02-20"}]' \
+  --evidence-soft-json '[{"source":"news","note":"earnings-call tone improved"}]' \
+  --as-of 2026-02-22T00:00:00+00:00
+```
+
+Validation guardrails:
+- `expected_return_low <= expected_return_high`
+- `confidence` must be between `0` and `1`
+- `--as-of` must be timezone-aware ISO-8601
+- `--evidence-hard-json` must be non-empty JSON array (HARD evidence required)
+
 ## Operator Dashboard
 
 - Run: `streamlit run src/dashboard/app.py`

--- a/migrations/010_forecast_record_idempotency.sql
+++ b/migrations/010_forecast_record_idempotency.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forecast_records_thesis_horizon_as_of
+ON forecast_records(thesis_id, horizon, as_of);

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -224,6 +224,11 @@ def run_streamlit_app(dsn: str) -> None:
             "Primary horizon (1M) learning metrics are not yet statistically reliable; treat KPI changes as directional only."
         )
 
+    if cards.get("forecast_count") == 0:
+        st.info(
+            "No forecast records yet. Seed the learning loop with `python3 -m src.ingestion.cli forecast-record-create ...` (see docs/ingestion-runbook.md)."
+        )
+
     c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16 = st.columns(16)
     c1.metric("Last Status", cards["last_run_status"], cards["last_run_time"])
     c2.metric("Raw", cards["raw_events"], _metric_delta(cards, "raw_events"))


### PR DESCRIPTION
## Why
Learning-loop KPIs are blocked when operators cannot safely seed forecast records without direct SQL.

## What
- Added `forecast-record-create` CLI command with strict validation for required forecast fields.
- Added idempotent repository write path (`thesis_id + horizon + as_of`) to deduplicate duplicate submissions safely.
- Added DB migration for unique idempotency index on forecast records.
- Added dashboard empty-state guidance when forecast table is empty.
- Updated ingestion runbook with a seed command and validation rules.
- Added tests for CLI validation/idempotency and repository ON CONFLICT behavior.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (88 passed)
