### PR TITLE
Fix dashboard percent metric parsing for '%' strings

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -56,8 +56,13 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         elif isinstance(value, (int, float)):
             raw = float(value)
         elif isinstance(value, str):
+            normalized = value.strip().replace(",", "")
+            scale = 1.0
+            if normalized.endswith("%"):
+                normalized = normalized[:-1].strip()
+                scale = 0.01
             try:
-                raw = float(value)
+                raw = float(normalized) * scale
             except ValueError:
                 return _metric("n/a", status="error", reason="invalid_numeric")
         else:

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -136,15 +136,15 @@ def test_dashboard_app_parses_numeric_strings_for_percent_metrics():
         {
             "learning_metrics": {
                 "realization_coverage": "0.4",
-                "hit_rate": "0.6",
-                "mean_abs_forecast_error": "0.025",
+                "hit_rate": "60%",
+                "mean_abs_forecast_error": "2.5%",
                 "mean_signed_forecast_error": "-0.007",
             },
             "attribution_summary": {
                 "hard_evidence_coverage": "0.86",
-                "hard_evidence_traceability_coverage": "0.71",
+                "hard_evidence_traceability_coverage": "71%",
                 "soft_evidence_coverage": "0.57",
-                "evidence_gap_coverage": "0.14",
+                "evidence_gap_coverage": "14%",
             },
         }
     )


### PR DESCRIPTION
## Why
Some dashboard metric inputs may arrive as human-formatted percentage strings (e.g., `60%`, `14%`). The current parser treats these as invalid numeric values and surfaces `n/a` with error status, which can trigger noisy critical alerts.

## What
- Updated percent metric parsing in `src/dashboard/app.py` to accept:
  - plain numeric strings (existing behavior)
  - percentage-suffixed strings (new)
  - comma-formatted numeric strings (new)
- Added/updated smoke test coverage in `tests/test_dashboard_app_smoke.py` to validate mixed ratio + percent-string inputs.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: 89 passed
