### PR TITLE
fix: enforce non-empty HARD evidence in forecast capture CLI

### DIFF
--- a/src/ingestion/cli.py
+++ b/src/ingestion/cli.py
@@ -205,6 +205,13 @@ def create_forecast_record_command(
     if not (0 <= confidence <= 1):
         raise ValueError("confidence must be between 0 and 1")
 
+    key_drivers = _parse_json_array(key_drivers_json, "key_drivers_json")
+    evidence_hard = _parse_json_array(evidence_hard_json, "evidence_hard_json")
+    evidence_soft = _parse_json_array(evidence_soft_json, "evidence_soft_json")
+
+    if not evidence_hard:
+        raise ValueError("evidence_hard_json must be a non-empty JSON array")
+
     payload = {
         "thesis_id": thesis_id,
         "horizon": horizon,
@@ -213,9 +220,9 @@ def create_forecast_record_command(
         "expected_volatility": expected_volatility,
         "expected_drawdown": expected_drawdown,
         "confidence": confidence,
-        "key_drivers": _parse_json_array(key_drivers_json, "key_drivers_json"),
-        "evidence_hard": _parse_json_array(evidence_hard_json, "evidence_hard_json"),
-        "evidence_soft": _parse_json_array(evidence_soft_json, "evidence_soft_json"),
+        "key_drivers": key_drivers,
+        "evidence_hard": evidence_hard,
+        "evidence_soft": evidence_soft,
         "as_of": _parse_iso_datetime(as_of, "as_of"),
     }
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -157,3 +157,19 @@ def test_create_forecast_record_command_rejects_invalid_range(monkeypatch):
             evidence_hard_json='[{"source":"fred"}]',
             as_of="2026-02-22T00:00:00+00:00",
         )
+
+
+def test_create_forecast_record_command_rejects_empty_hard_evidence(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgres://example")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        cli.create_forecast_record_command(
+            thesis_id="thesis-1",
+            horizon="1M",
+            expected_return_low=0.01,
+            expected_return_high=0.03,
+            confidence=0.6,
+            key_drivers_json="[]",
+            evidence_hard_json="[]",
+            as_of="2026-02-22T00:00:00+00:00",
+        )


### PR DESCRIPTION
## Why
Issue #57 requires operator-safe forecast capture with strict validation to prevent low-quality records entering learning metrics.

## What
- Added explicit validation in  to reject empty  payloads.
- Kept existing range/confidence/as-of validations intact.
- Added unit test coverage for empty HARD-evidence rejection.

## Validation
- ........................................................................ [ 80%]
..................                                                       [100%]
90 passed in 0.23s (90 passed)

Closes #57