### PR TITLE
Fix #55: reliability badge + readable reason in multi-horizon learning panel

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -93,6 +93,8 @@ Validation guardrails:
   - last run status/time
   - raw/canonical/quarantine counters
   - multi-horizon learning metrics with reliability guardrails (`insufficient` / `low_sample` / `reliable`)
+    - reliability badges: `🔴 insufficient`, `🟠 low_sample`, `🟢 reliable`
+    - each row includes a human-readable reliability reason to prevent over-trusting sparse KPI samples
   - recent run history
 - Reliability threshold env overrides:
   - `LEARNING_RELIABILITY_MIN_REALIZED_1W` (default: `8`)

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -96,6 +96,11 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["has_critical_metric_alert"] is False
     assert len(cards["learning_metrics_panel"]) == 3
     assert cards["learning_metrics_panel"][0]["horizon"] == "1W"
+    assert cards["learning_metrics_panel"][0]["reliability_badge"] == "🟢 reliable"
+    assert (
+        cards["learning_metrics_panel"][0]["reliability_reason_text"]
+        == "Sample size and coverage meet reliability threshold."
+    )
 
 
 def test_dashboard_app_treats_malformed_count_metrics_as_unknown_or_error():
@@ -263,4 +268,6 @@ def test_dashboard_app_flags_primary_horizon_reliability_guardrail():
 
     assert cards["has_primary_horizon_reliability_alert"] is True
     assert cards["learning_metrics_panel"][1]["reliability"] == "insufficient"
+    assert cards["learning_metrics_panel"][1]["reliability_badge"] == "🔴 insufficient"
+    assert "Realized sample below minimum" in cards["learning_metrics_panel"][1]["reliability_reason_text"]
     assert cards["learning_metrics_panel"][1]["status"] == "warn"


### PR DESCRIPTION
## Why
Issue #55 requires explicit reliability signaling so sparse-sample horizons are not over-trusted.

## What
- Add reliability badge mapping in dashboard cards:
  - 🔴 insufficient
  - 🟠 low_sample
  - 🟢 reliable
- Add human-readable reliability reason text derived from deterministic backend reason codes.
- Keep existing reliability state/reason fields unchanged for machine-readability.
- Update runbook with badge semantics and reason-text behavior.
- Add tests for badge/reason-text rendering and primary-horizon reliability warning case.

## Validation
- FRED_API_KEY= ECOS_API_KEY= pytest -q
- Result: 90 passed
