### PR TITLE
feat: add dashboard policy compliance panel for locked constraints

### DIFF
--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -96,6 +96,8 @@ def test_dashboard_app_builds_cards_from_view_model():
     assert cards["has_critical_metric_alert"] is False
     assert len(cards["learning_metrics_panel"]) == 3
     assert cards["learning_metrics_panel"][0]["horizon"] == "1W"
+    assert len(cards["policy_compliance_panel"]) >= 10
+    assert cards["policy_compliance_panel"][0]["policy_item"] == "Universe"
     assert cards["learning_metrics_panel"][0]["reliability_badge"] == "🟢 reliable"
     assert (
         cards["learning_metrics_panel"][0]["reliability_reason_text"]


### PR DESCRIPTION
## Why
- Operators need a visible policy-lock checklist in the dashboard to confirm the run context remains aligned with locked constraints (US/KR/Crypto scope, risk guardrails, benchmark, cadence).

## What
- Added a new **Policy Compliance (Locked Constraints)** panel in Streamlit dashboard.
- Introduced a fixed locked-policy row set matching POLICY_LOCK_V1 ground rules.
- Exposed  from .
- Added smoke-test assertions for panel presence/content.

## Validation
- ........................................................................ [ 80%]
..................                                                       [100%]
90 passed in 0.22s
- Result: 90 passed
