### PR TITLE
Handle non-finite dashboard metrics safely

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,4 +1,5 @@
 import os
+import math
 import importlib
 from collections.abc import Mapping
 
@@ -73,15 +74,20 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
         if isinstance(value, int):
             return _metric(value)
         if isinstance(value, float):
+            if not math.isfinite(value):
+                return _metric("n/a", status="error", reason="non_finite_numeric")
             return _metric(int(value))
         if isinstance(value, str):
             try:
                 return _metric(int(value))
             except ValueError:
                 try:
-                    return _metric(int(float(value)))
+                    parsed = float(value)
                 except ValueError:
                     return _metric("n/a", status="error", reason="invalid_numeric")
+                if not math.isfinite(parsed):
+                    return _metric("n/a", status="error", reason="non_finite_numeric")
+                return _metric(int(parsed))
         return _metric("n/a", status="error", reason="unsupported_type")
 
     def to_pct_metric(value: object, precision: int) -> dict[str, object]:
@@ -103,6 +109,8 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
                 return _metric("n/a", status="error", reason="invalid_numeric")
         else:
             return _metric("n/a", status="error", reason="unsupported_type")
+        if not math.isfinite(raw):
+            return _metric("n/a", status="error", reason="non_finite_numeric")
         return _metric(f"{raw * 100:.{precision}f}%")
 
     counters = view.get("counters", {})

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 
 
 dashboard_app = importlib.import_module("src.dashboard.app")
@@ -273,3 +274,27 @@ def test_dashboard_app_flags_primary_horizon_reliability_guardrail():
     assert cards["learning_metrics_panel"][1]["reliability_badge"] == "🔴 insufficient"
     assert "Realized sample below minimum" in cards["learning_metrics_panel"][1]["reliability_reason_text"]
     assert cards["learning_metrics_panel"][1]["status"] == "warn"
+
+
+def test_dashboard_app_marks_non_finite_numbers_as_error_not_crash():
+    cards = dashboard_app.build_operator_cards(
+        {
+            "counters": {
+                "raw_events": math.nan,
+            },
+            "learning_metrics": {
+                "realization_coverage": "NaN",
+                "hit_rate": math.inf,
+            },
+            "attribution_summary": {
+                "hard_evidence_coverage": "inf",
+            },
+        }
+    )
+
+    assert cards["raw_events"] == "n/a"
+    assert cards["coverage_pct"] == "n/a"
+    assert cards["hit_rate_pct"] == "n/a"
+    assert cards["hard_evidence_pct"] == "n/a"
+    assert cards["metric_status"]["raw_events"]["status"] == "error"
+    assert cards["metric_status"]["coverage_pct"]["reason"] == "non_finite_numeric"


### PR DESCRIPTION
## Why
Dashboard card parsing could crash or emit misleading values when upstream data includes non-finite numerics (NaN/Inf). This is user-facing risk for Streamlit cards.

## What
- Guard int metric conversion against non-finite float values.
- Guard percent metric conversion against non-finite parsed/raw values.
- Add regression test ensuring NaN/Inf are surfaced as  with explicit error status instead of crashing.

## Validation
- ........................................................................ [ 79%]
...................                                                      [100%]
91 passed in 1.11s (91 passed)
