### PR TITLE
Add policy compliance checks panel to dashboard

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -96,6 +96,13 @@ Validation guardrails:
     - reliability badges: `🔴 insufficient`, `🟠 low_sample`, `🟢 reliable`
     - each row includes a human-readable reliability reason to prevent over-trusting sparse KPI samples
   - recent run history
+  - policy compliance block (PASS/WARN/FAIL/UNKNOWN):
+    - Universe coverage (US/KR/Crypto): currently validated via ingestion presence; region-level tagging dependency surfaced in evidence
+    - Crypto sleeve composition (BTC/ETH >=70%, alts <=30%): `UNKNOWN` until portfolio sleeve exposure feed exists
+    - Leverage sleeve cap (<=20%): `UNKNOWN` until portfolio leverage exposure feed exists
+    - Primary horizon readiness (1M): mapped from reliability state (`reliable`→PASS, `low_sample`→WARN, `insufficient`→FAIL)
+    - Benchmark readiness (QQQ/KOSPI200/BTC/SGOV): checks latest `macro_series_points` presence per component
+    - Summary counters shown for PASS/WARN/FAIL/UNKNOWN (no silent PASS on missing dependencies)
 - Reliability threshold env overrides:
   - `LEARNING_RELIABILITY_MIN_REALIZED_1W` (default: `8`)
   - `LEARNING_RELIABILITY_MIN_REALIZED_1M` (default: `12`)


### PR DESCRIPTION
## Why
Policy Lock v1.1 requires at-a-glance compliance checks in the operator dashboard so users can quickly see PASS/WARN/FAIL/UNKNOWN state with evidence.

## What
- Added policy compliance evaluator in dashboard service for 5 checks:
  - Universe coverage
  - Crypto sleeve composition
  - Leverage sleeve cap
  - Primary horizon readiness (1M)
  - Benchmark readiness (QQQ/KOSPI200/BTC/SGOV)
- Added compliance summary counters (pass/warn/fail/unknown)
- Updated Streamlit UI to render summary metrics + compliance table
- Added unit tests for policy classification and missing benchmark dependency behavior
- Updated runbook with policy compliance definitions/dependencies

## Validation
- ........................................................................ [ 77%]
.....................                                                    [100%]
93 passed in 0.23s (93 passed)
