### PR TITLE
Policy compliance: add explicit as_of fallback for operator traceability

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -103,6 +103,7 @@ Validation guardrails:
     - Primary horizon readiness (1M): mapped from reliability state (`reliable`→PASS, `low_sample`→WARN, `insufficient`→FAIL)
     - Benchmark readiness (QQQ/KOSPI200/BTC/SGOV): checks latest `macro_series_points` presence per component
     - Summary counters shown for PASS/WARN/FAIL/UNKNOWN (no silent PASS on missing dependencies)
+    - Each check exposes `as_of`; when direct evidence timestamp is unavailable, dashboard falls back to latest successful run time so operators can trace data recency explicitly
 - Reliability threshold env overrides:
   - `LEARNING_RELIABILITY_MIN_REALIZED_1W` (default: `8`)
   - `LEARNING_RELIABILITY_MIN_REALIZED_1M` (default: `12`)

--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -209,6 +209,7 @@ def _build_policy_compliance(
     repository: DashboardRepositoryProtocol,
     counters: dict[str, object],
     learning_metrics_by_horizon: dict[str, dict[str, object]],
+    latest_run_time: str | None,
 ) -> dict[str, object]:
     checks: list[dict[str, object]] = []
 
@@ -225,7 +226,7 @@ def _build_policy_compliance(
             "check": "Universe coverage (US/KR/Crypto)",
             "status": universe_status,
             "reason": universe_reason,
-            "as_of": None,
+            "as_of": latest_run_time,
             "evidence": {
                 "raw_events": raw_events,
                 "canonical_events": canonical_events,
@@ -239,7 +240,7 @@ def _build_policy_compliance(
             "check": "Crypto sleeve composition (BTC/ETH >=70%, alts <=30%)",
             "status": "UNKNOWN",
             "reason": "Portfolio crypto sleeve exposure feed not available.",
-            "as_of": None,
+            "as_of": latest_run_time,
             "evidence": {"dependency": "portfolio_exposure_crypto_sleeve"},
         }
     )
@@ -248,7 +249,7 @@ def _build_policy_compliance(
             "check": "Leverage sleeve cap (<=20%)",
             "status": "UNKNOWN",
             "reason": "Portfolio leverage exposure feed not available.",
-            "as_of": None,
+            "as_of": latest_run_time,
             "evidence": {"dependency": "portfolio_exposure_leverage_sleeve"},
         }
     )
@@ -266,7 +267,7 @@ def _build_policy_compliance(
             "check": "Primary horizon readiness (1M)",
             "status": primary_status,
             "reason": str(primary.get("reliability_reason", "missing_reliability_metadata")),
-            "as_of": None,
+            "as_of": latest_run_time,
             "evidence": {
                 "reliability_state": reliability,
                 "realized_count": primary.get("realized_count", 0),
@@ -305,7 +306,7 @@ def _build_policy_compliance(
             "check": "Benchmark readiness (QQQ/KOSPI200/BTC/SGOV)",
             "status": benchmark_status,
             "reason": benchmark_reason,
-            "as_of": max([v for v in benchmark_as_of.values() if v is not None], default=None),
+            "as_of": max([v for v in benchmark_as_of.values() if v is not None], default=latest_run_time),
             "evidence": {
                 "series_point_count": benchmark_points,
                 "series_latest_as_of": benchmark_as_of,
@@ -497,6 +498,7 @@ def build_dashboard_view(
             repository=repository,
             counters=counters if isinstance(counters, dict) else {},
             learning_metrics_by_horizon=learning_metrics_by_horizon,
+            latest_run_time=last_run_time or None,
         ),
         "recent_runs": recent_runs,
     }

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -219,6 +219,16 @@ def test_dashboard_service_policy_compliance_marks_missing_benchmark_dependencie
     assert "Missing benchmark series" in benchmark_check["reason"]
 
 
+def test_dashboard_service_policy_checks_include_as_of_from_latest_run_when_direct_evidence_missing():
+    view = build_dashboard_view(FakeDashboardRepo())
+    checks = view["policy_compliance"]["checks"]
+
+    assert checks[0]["as_of"] == "2026-02-18T01:00:00Z"
+    assert checks[1]["as_of"] == "2026-02-18T01:00:00Z"
+    assert checks[2]["as_of"] == "2026-02-18T01:00:00Z"
+    assert checks[3]["as_of"] == "2026-02-18T01:00:00Z"
+
+
 def test_dashboard_service_learning_reliability_threshold_env_override(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("LEARNING_RELIABILITY_MIN_REALIZED_1M", "10")
     monkeypatch.setenv("LEARNING_RELIABILITY_COVERAGE_FLOOR", "0.65")


### PR DESCRIPTION
## Why
Policy Compliance checks showed `as_of: null` for checks driven by counters/reliability or missing upstream feeds. That made recency ambiguous during operations and increased manual tracing burden.

## What
- add `latest_run_time` input to policy-compliance builder
- set `as_of` for universe/crypto sleeve/leverage sleeve/primary-horizon checks to latest run timestamp when direct evidence timestamp is unavailable
- keep benchmark check `as_of` from series timestamps, with latest-run fallback if all are missing
- add unit test coverage for `as_of` fallback behavior
- document `as_of` fallback semantics in ingestion runbook

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
  - 94 passed
