### PR TITLE
Fix #70: add Streamlit auth-wall access smoke check + runbook policy

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -118,4 +118,24 @@ Validation guardrails:
 4. Select branch: `main`.
 5. Set Main file path: `streamlit_app.py`.
 6. Set Secret: `SUPABASE_DB_URL` (or `DATABASE_URL`).
-7. Deploy and copy the generated app URL (`https://<app-name>.streamlit.app`).
+7. **Access policy:** set app visibility to the intended operator mode.
+   - Default production contract: `Public` (unauthenticated dashboard shell must be reachable).
+   - If restricted mode is required, deployment owner must document explicit access instructions and expected operator accounts.
+8. Deploy and copy the generated app URL (`https://<app-name>.streamlit.app`).
+
+### Dashboard access contract smoke check
+
+Run from CI or post-deploy:
+
+```bash
+python3 -m src.ingestion.cli streamlit-access-check --url https://finance-flow-labs.streamlit.app/
+```
+
+Expected behavior:
+- Exit code `0`: app shell reachable and no Streamlit auth-wall redirect detected.
+- Exit code `2`: access contract broken (e.g., redirected to `https://share.streamlit.io/-/auth/app`).
+
+Operational response when check fails:
+1. Verify Streamlit app visibility/access policy in deployment settings.
+2. Re-run check from a clean network session.
+3. If intentionally restricted, update this runbook + monitoring expectation and provide operator login instructions.

--- a/src/ingestion/streamlit_access.py
+++ b/src/ingestion/streamlit_access.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+
+AUTH_WALL_HOST = "share.streamlit.io"
+AUTH_WALL_PATH_PREFIX = "/-/auth/app"
+
+
+@dataclass(frozen=True)
+class AccessCheckResult:
+    ok: bool
+    status_code: int | None
+    final_url: str
+    auth_wall_redirect: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "status_code": self.status_code,
+            "final_url": self.final_url,
+            "auth_wall_redirect": self.auth_wall_redirect,
+            "reason": self.reason,
+        }
+
+
+def _default_fetch(url: str, timeout_seconds: float) -> tuple[int | None, str, Mapping[str, str], str]:
+    request = Request(url=url, method="GET")
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            status_code = getattr(response, "status", None)
+            final_url = response.geturl()
+            headers = dict(response.headers.items())
+            body = response.read(4096).decode("utf-8", errors="replace")
+            return status_code, final_url, headers, body
+    except HTTPError as exc:
+        body = exc.read(4096).decode("utf-8", errors="replace")
+        return exc.code, exc.geturl() or url, dict(exc.headers.items()), body
+
+
+def _is_auth_wall_url(url: str) -> bool:
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.netloc == AUTH_WALL_HOST and parsed.path.startswith(AUTH_WALL_PATH_PREFIX)
+
+
+def check_streamlit_access(
+    url: str,
+    *,
+    timeout_seconds: float = 15,
+    fetch: Callable[[str, float], tuple[int | None, str, Mapping[str, str], str]] | None = None,
+) -> AccessCheckResult:
+    fetch_fn = fetch or _default_fetch
+
+    try:
+        status_code, final_url, headers, body = fetch_fn(url, timeout_seconds)
+    except URLError as exc:
+        return AccessCheckResult(
+            ok=False,
+            status_code=None,
+            final_url=url,
+            auth_wall_redirect=False,
+            reason=f"network_error:{exc.reason}",
+        )
+
+    location = headers.get("Location") or headers.get("location")
+    auth_wall_redirect = _is_auth_wall_url(final_url)
+    if not auth_wall_redirect and isinstance(location, str):
+        next_url = urljoin(url, location)
+        auth_wall_redirect = _is_auth_wall_url(next_url)
+
+    if auth_wall_redirect:
+        return AccessCheckResult(
+            ok=False,
+            status_code=status_code,
+            final_url=final_url,
+            auth_wall_redirect=True,
+            reason="auth_wall_redirect_detected",
+        )
+
+    normalized_body = body.lower()
+    has_streamlit_shell_hint = "streamlit" in normalized_body or "__next" in normalized_body
+    if status_code in {200, 304} and has_streamlit_shell_hint:
+        return AccessCheckResult(
+            ok=True,
+            status_code=status_code,
+            final_url=final_url,
+            auth_wall_redirect=False,
+            reason="ok",
+        )
+
+    return AccessCheckResult(
+        ok=False,
+        status_code=status_code,
+        final_url=final_url,
+        auth_wall_redirect=False,
+        reason="unexpected_response",
+    )


### PR DESCRIPTION
## Why\nUnauthenticated access to the Streamlit dashboard can regress into a redirect to Streamlit auth wall (), which makes operator monitoring unavailable.\n\n## What\n- add  to detect auth-wall redirect vs dashboard shell\n- add CLI command: \n- return exit code  when access contract fails (auth-wall or non-shell payload)\n- add tests for redirect detection and parser/command wiring\n- document deployment access contract + incident response in runbook\n\n## Validation\n- ........................................................................ [ 72%]
............................                                             [100%]
100 passed in 0.25s\n- {"ok": false, "status_code": 303, "final_url": "https://finance-flow-labs.streamlit.app/", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected"} (currently returns auth-wall detected + exit 2, confirming detector works)\n\n## Policy alignment\n- Keeps HARD/SOFT evidence separation untouched\n- Improves operator observability reliability without destructive changes