### PR TITLE
Add benchmark staleness guard to policy checks

### DIFF
--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -219,6 +219,18 @@ def test_dashboard_service_policy_compliance_marks_missing_benchmark_dependencie
     assert "Missing benchmark series" in benchmark_check["reason"]
 
 
+def test_dashboard_service_policy_compliance_marks_stale_benchmark_dependencies_warn():
+    class StaleBenchmarkRepo(FakeDashboardRepo):
+        def read_macro_series_points(self, metric_key, limit=1):
+            return [{"metric_key": metric_key, "as_of": "2026-02-01T00:00:00Z", "value": 1.0}]
+
+    view = build_dashboard_view(StaleBenchmarkRepo())
+    benchmark_check = view["policy_compliance"]["checks"][7]
+    assert benchmark_check["status"] == "WARN"
+    assert "Stale benchmark series" in benchmark_check["reason"]
+    assert benchmark_check["evidence"]["series_age_days"]["QQQ"] >= 17
+
+
 def test_dashboard_service_policy_checks_include_as_of_from_latest_run_when_direct_evidence_missing():
     view = build_dashboard_view(FakeDashboardRepo())
     checks = view["policy_compliance"]["checks"]


### PR DESCRIPTION
## Why
Benchmark readiness currently checks only for missing series, not stale series. This can mask outdated benchmark components and produce false PASS states.

## What
- Added staleness detection to benchmark policy check in dashboard service
- Introduced configurable threshold  (default: 7)
- Extended benchmark evidence with  and 
- Added test coverage for stale benchmark warning behavior

## Validation
- ........................................................................ [ 71%]
.............................                                            [100%]
101 passed in 0.26s (101 passed)
