### PR TITLE
Refactor operator KPI strip into responsive priority tiers

### DIFF
--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -9,6 +9,34 @@ def test_dashboard_app_module_loads():
     assert hasattr(dashboard_app, "build_operator_cards")
 
 
+def test_dashboard_app_kpi_layout_is_tiered_and_bounded():
+    tiers = dashboard_app.get_kpi_layout_tiers()
+    assert all(len(keys) <= 6 for _, keys in tiers)
+
+    rendered_keys = {key for _, keys in tiers for key in keys}
+    assert rendered_keys == {
+        "last_status",
+        "primary_reliability",
+        "policy_summary",
+        "evidence_gap_count",
+        "raw_events",
+        "canonical_events",
+        "quarantine_events",
+        "forecast_count",
+        "realized_count",
+        "coverage_pct",
+        "hit_rate_pct",
+        "mae_pct",
+        "signed_error_pct",
+        "attribution_total",
+        "attribution_top_category",
+        "hard_evidence_pct",
+        "hard_evidence_traceability_pct",
+        "soft_evidence_pct",
+        "evidence_gap_pct",
+    }
+
+
 def test_dashboard_app_builds_cards_from_view_model():
     cards = dashboard_app.build_operator_cards(
         {


### PR DESCRIPTION
## Why
- Resolves #71 by removing the 16-column KPI strip that compresses critical information on normal laptop widths.
- Improves top-down operator triage for critical policy/reliability/evidence signals.

## What
- Replaced fixed st.columns(16) KPI strip with tiered KPI rows (critical/core/diagnostic), each row capped at 6 cards.
- Kept existing KPI values and metric status deltas for existing cards.
- Added critical-first cards for 1M reliability and policy summary while preserving policy summary panel above detailed table.
- Added layout smoke test to assert row width cap (<=6) and prevent metric-key omission regressions.

## Validation
- FRED_API_KEY= ECOS_API_KEY= pytest -q
- Result: 102 passed
