### PR TITLE
Fix Streamlit auth-wall detection for /-/login redirect loops

### DIFF
--- a/tests/test_streamlit_access.py
+++ b/tests/test_streamlit_access.py
@@ -43,6 +43,25 @@ def test_check_streamlit_access_detects_auth_wall_from_location_header():
     assert result.auth_wall_redirect is True
 
 
+def test_check_streamlit_access_detects_streamlit_login_redirect_loop():
+    def fake_fetch(url: str, timeout_seconds: float):
+        return (
+            303,
+            "https://finance-flow-labs.streamlit.app/-/login?payload=abc123",
+            {},
+            "",
+        )
+
+    result = streamlit_access.check_streamlit_access(
+        "https://finance-flow-labs.streamlit.app/",
+        fetch=fake_fetch,
+    )
+
+    assert result.ok is False
+    assert result.auth_wall_redirect is True
+    assert result.reason == "auth_wall_redirect_detected"
+
+
 def test_check_streamlit_access_accepts_streamlit_shell_response():
     def fake_fetch(url: str, timeout_seconds: float):
         return (


### PR DESCRIPTION
## Why
Production URL currently returns a Streamlit auth/login redirect loop (303 chain). We already detect direct redirects to `share.streamlit.io/-/auth/app`, but some responses surface app-local `/-/login?payload=...` first. That can be misclassified as `unexpected_response` in downstream checks.

## What
- Extend auth-wall URL detection to treat `/-/login` with `payload` as auth-wall redirect behavior.
- Keep existing `share.streamlit.io/-/auth/app` detection unchanged.
- Add regression test for app-local login redirect loop.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `103 passed`
