### PR TITLE
Fix #75: prevent false PASS by surfacing region-aware universe evidence

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -97,7 +97,7 @@ Validation guardrails:
     - each row includes a human-readable reliability reason to prevent over-trusting sparse KPI samples
   - recent run history
   - policy compliance block (PASS/WARN/FAIL/UNKNOWN):
-    - Universe coverage (US/KR/Crypto): currently validated via ingestion presence; region-level tagging dependency surfaced in evidence
+    - Universe coverage (US/KR/Crypto): requires region-aware HARD evidence by policy region (US/KR/CRYPTO); panel surfaces per-region evidence counts + metadata completeness ratio + evaluation `as_of`
     - Crypto sleeve composition (BTC/ETH >=70%, alts <=30%): `UNKNOWN` until portfolio sleeve exposure feed exists
     - Leverage sleeve cap (<=20%): `UNKNOWN` until portfolio leverage exposure feed exists
     - Primary horizon readiness (1M): mapped from reliability state (`reliable`→PASS, `low_sample`→WARN, `insufficient`→FAIL)

--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -262,9 +262,19 @@ def _build_policy_compliance(
                     )
                     break
 
+    required_region_count = len(POLICY_UNIVERSE_REGION_SENTINELS)
+    present_region_count = sum(1 for is_present in universe_regions_present.values() if is_present)
     missing_regions = [
         region for region, is_present in universe_regions_present.items() if not is_present
     ]
+    region_coverage_counts = {
+        region: len(universe_region_evidence.get(region, []))
+        for region in POLICY_UNIVERSE_REGION_SENTINELS
+    }
+    region_metadata_completeness = (
+        present_region_count / required_region_count if required_region_count > 0 else 0.0
+    )
+
     if all(universe_regions_present.values()):
         universe_status = "PASS"
         universe_reason = "Region-aware HARD evidence confirms US/KR/Crypto coverage."
@@ -290,6 +300,10 @@ def _build_policy_compliance(
                 "regions_present": universe_regions_present,
                 "missing_regions": missing_regions,
                 "region_metric_evidence": universe_region_evidence,
+                "region_coverage_counts": region_coverage_counts,
+                "required_region_count": required_region_count,
+                "present_region_count": present_region_count,
+                "region_metadata_completeness": region_metadata_completeness,
                 "region_dimension_ready": all(universe_regions_present.values()),
             },
         }

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -328,6 +328,35 @@ def test_dashboard_app_uses_policy_compliance_payload_when_present():
     assert cards["policy_compliance_summary"]["fail"] == 1
 
 
+def test_dashboard_app_policy_panel_surfaces_universe_region_evidence_columns():
+    cards = dashboard_app.build_operator_cards(
+        {
+            "policy_compliance": {
+                "checks": [
+                    {
+                        "check": "Universe coverage (US/KR/Crypto)",
+                        "status": "WARN",
+                        "reason": "Ingest data exists but region-aware coverage evidence is incomplete: KR",
+                        "as_of": "2026-02-22T11:20:00Z",
+                        "evidence": {
+                            "region_coverage_counts": {"US": 1, "KR": 0, "CRYPTO": 1},
+                            "region_metadata_completeness": 2 / 3,
+                        },
+                    }
+                ],
+                "summary": {"total": 1, "pass": 0, "warn": 1, "fail": 0, "unknown": 0},
+            }
+        }
+    )
+
+    row = cards["policy_compliance_panel"][0]
+    assert row["us_coverage_count"] == 1
+    assert row["kr_coverage_count"] == 0
+    assert row["crypto_coverage_count"] == 1
+    assert row["region_metadata_completeness"] == "66.7%"
+    assert row["evaluation_window_as_of"] == "2026-02-22T11:20:00Z"
+
+
 def test_dashboard_app_marks_non_finite_numbers_as_error_not_crash():
     cards = dashboard_app.build_operator_cards(
         {

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -241,6 +241,10 @@ def test_dashboard_service_universe_compliance_requires_region_evidence_for_each
         "CRYPTO": True,
     }
     assert universe_check["evidence"]["missing_regions"] == ["KR"]
+    assert universe_check["evidence"]["region_coverage_counts"] == {"US": 1, "KR": 0, "CRYPTO": 1}
+    assert universe_check["evidence"]["present_region_count"] == 2
+    assert universe_check["evidence"]["required_region_count"] == 3
+    assert universe_check["evidence"]["region_metadata_completeness"] == pytest.approx(2 / 3)
 
 
 def test_dashboard_service_policy_compliance_marks_stale_benchmark_dependencies_warn():


### PR DESCRIPTION
## Why
Universe compliance could appear green without explicit region-level evidence, which risks false confidence versus locked US/KR/Crypto policy requirements.

## What
- Added region evidence rollup fields to universe compliance evidence:
  -  (US/KR/CRYPTO)
  -  / 
  - 
- Kept non-PASS behavior when region evidence is incomplete.
- Flattened universe-specific evidence fields into dashboard policy panel rows so operators can directly see:
  - per-region counts
  - completeness percentage
  - evaluation window 
- Updated runbook wording to reflect strict region-aware validation semantics.
- Added/updated tests for service evidence mapping and dashboard rendering columns.

## Validation
- ........................................................................ [ 68%]
.................................                                        [100%]
105 passed in 0.25s
- Result: 
