### PR TITLE
feat: add machine-readable alert severity to streamlit access check

### DIFF
--- a/src/ingestion/streamlit_access.py
+++ b/src/ingestion/streamlit_access.py
@@ -20,6 +20,18 @@ class AccessCheckResult:
     auth_wall_redirect: bool
     reason: str
 
+    @property
+    def alert(self) -> bool:
+        return not self.ok
+
+    @property
+    def alert_severity(self) -> str:
+        if self.ok:
+            return "none"
+        if self.auth_wall_redirect:
+            return "critical"
+        return "warning"
+
     def to_dict(self) -> dict[str, object]:
         return {
             "ok": self.ok,
@@ -27,6 +39,8 @@ class AccessCheckResult:
             "final_url": self.final_url,
             "auth_wall_redirect": self.auth_wall_redirect,
             "reason": self.reason,
+            "alert": self.alert,
+            "alert_severity": self.alert_severity,
         }
 
 

--- a/tests/test_streamlit_access.py
+++ b/tests/test_streamlit_access.py
@@ -92,3 +92,18 @@ def test_check_streamlit_access_flags_non_shell_payload_as_unexpected():
     assert result.ok is False
     assert result.auth_wall_redirect is False
     assert result.reason == "unexpected_response"
+
+
+def test_access_check_result_serializes_alert_fields():
+    result = streamlit_access.AccessCheckResult(
+        ok=False,
+        status_code=303,
+        final_url="https://finance-flow-labs.streamlit.app/",
+        auth_wall_redirect=True,
+        reason="auth_wall_redirect_detected",
+    )
+
+    payload = result.to_dict()
+
+    assert payload["alert"] is True
+    assert payload["alert_severity"] == "critical"


### PR DESCRIPTION
## Why
Issue #70 calls for monitoring alert behavior when the Streamlit endpoint regresses to auth-wall redirect.

## What
- Added  and  fields to 
- Added severity mapping ( for auth-wall redirects,  for other failures)
- Added unit test validating serialized alert fields

## Validation
- ...................                                                      [100%]
19 passed in 0.10s
- ........................................................................ [ 67%]
..................................                                       [100%]
106 passed in 0.26s
