### PR TITLE
Harden Streamlit access smoke check with bounded retries

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -139,3 +139,18 @@ Operational response when check fails:
 1. Verify Streamlit app visibility/access policy in deployment settings.
 2. Re-run check from a clean network session.
 3. If intentionally restricted, update this runbook + monitoring expectation and provide operator login instructions.
+
+### Reliability hardening for smoke checks
+
+- `streamlit-access-check` supports bounded retries to reduce transient-network false positives:
+  - `--attempts` (default: `3`)
+  - `--backoff-seconds` (default: `0.5`, linear backoff)
+- Retries apply only to `network_error:*` cases; auth-wall redirects fail immediately as critical.
+- Recommended CI/deploy invocation:
+
+```bash
+python3 -m src.ingestion.cli streamlit-access-check \
+  --url https://finance-flow-labs.streamlit.app/ \
+  --attempts 3 \
+  --backoff-seconds 0.5
+```

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -91,6 +91,8 @@ def test_cli_exposes_streamlit_access_check_command_with_defaults():
     assert args.command == "streamlit-access-check"
     assert args.url == "https://finance-flow-labs.streamlit.app/"
     assert args.timeout_seconds == 15
+    assert args.attempts == 3
+    assert args.backoff_seconds == 0.5
 
 
 def test_run_streamlit_access_check_command_returns_serializable_dict(monkeypatch):
@@ -106,15 +108,25 @@ def test_run_streamlit_access_check_command_returns_serializable_dict(monkeypatc
 
     class FakeModule:
         @staticmethod
-        def check_streamlit_access(url: str, timeout_seconds: float):
+        def check_streamlit_access(
+            url: str,
+            timeout_seconds: float,
+            attempts: int,
+            backoff_seconds: float,
+        ):
             assert url == "https://finance-flow-labs.streamlit.app/"
             assert timeout_seconds == 9
+            assert attempts == 4
+            assert backoff_seconds == 0.2
             return FakeResult()
 
     monkeypatch.setattr(cli.importlib, "import_module", lambda _: FakeModule())
 
     result = cli.run_streamlit_access_check_command(
-        "https://finance-flow-labs.streamlit.app/", timeout_seconds=9
+        "https://finance-flow-labs.streamlit.app/",
+        timeout_seconds=9,
+        attempts=4,
+        backoff_seconds=0.2,
     )
 
     assert result["auth_wall_redirect"] is True


### PR DESCRIPTION
## Why
Streamlit unauthenticated access checks can produce false negatives during transient network hiccups, which weakens confidence in the auth-wall regression signal for issue #70.

## What
- Added bounded retry/backoff support to `streamlit-access-check`:
  - `--attempts` (default `3`)
  - `--backoff-seconds` (default `0.5`, linear backoff)
- Retry behavior is limited to transient `network_error:*` results.
- Auth-wall redirect detections still fail immediately as critical (no retry masking).
- Updated runbook with hardened invocation guidance.
- Added unit tests for retry behavior and CLI argument wiring.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `108 passed`
