### PR TITLE
Issue #70: add deploy-ready Streamlit access smoke script

### DIFF
--- a/scripts/streamlit_access_smoke_check.sh
+++ b/scripts/streamlit_access_smoke_check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-https://finance-flow-labs.streamlit.app/}"
+ATTEMPTS="${ATTEMPTS:-3}"
+BACKOFF_SECONDS="${BACKOFF_SECONDS:-0.5}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-15}"
+
+python3 -m src.ingestion.cli streamlit-access-check \
+  --url "$URL" \
+  --attempts "$ATTEMPTS" \
+  --backoff-seconds "$BACKOFF_SECONDS" \
+  --timeout-seconds "$TIMEOUT_SECONDS"


### PR DESCRIPTION
## Why
Unauthenticated access to the Streamlit dashboard currently regresses to an auth-wall redirect (`share.streamlit.io/-/auth/app`).
We need an operator-safe, repeatable contract check and explicit incident handling guidance so regressions are detected immediately.

## What
- Added executable smoke-check script: `scripts/streamlit_access_smoke_check.sh`
  - wraps `python -m src.ingestion.cli streamlit-access-check`
  - supports retry/backoff/timeout controls via env vars
- Updated runbook: `docs/ingestion-runbook.md`
  - rollback steps for auth-wall regressions
  - canonical script-based CI/deploy invocation
  - explicit alert trigger/clear contract

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- `./scripts/streamlit_access_smoke_check.sh https://finance-flow-labs.streamlit.app/`
  - currently returns `auth_wall_redirect_detected` (critical), confirming detector correctness against live production behavior

Closes #70
