### PR TITLE
Fix Streamlit auth-wall detection using redirect history

### DIFF
--- a/tests/test_streamlit_access.py
+++ b/tests/test_streamlit_access.py
@@ -80,6 +80,29 @@ def test_check_streamlit_access_accepts_streamlit_shell_response():
     assert result.reason == "ok"
 
 
+def test_check_streamlit_access_detects_auth_wall_from_redirect_history_even_if_final_url_recovers():
+    def fake_fetch(url: str, timeout_seconds: float):
+        return (
+            200,
+            "https://finance-flow-labs.streamlit.app/",
+            {},
+            "<!doctype html><title>Streamlit</title>",
+            [
+                "https://share.streamlit.io/-/auth/app?redirect_uri=https%3A%2F%2Ffinance-flow-labs.streamlit.app%2F",
+                "https://finance-flow-labs.streamlit.app/-/login?payload=abc123",
+            ],
+        )
+
+    result = streamlit_access.check_streamlit_access(
+        "https://finance-flow-labs.streamlit.app/",
+        fetch=fake_fetch,
+    )
+
+    assert result.ok is False
+    assert result.auth_wall_redirect is True
+    assert result.reason == "auth_wall_redirect_detected"
+
+
 def test_check_streamlit_access_flags_non_shell_payload_as_unexpected():
     def fake_fetch(url: str, timeout_seconds: float):
         return (200, "https://finance-flow-labs.streamlit.app/", {}, "plain text")


### PR DESCRIPTION
## Why
- Live dashboard checks could report false `ok` when Streamlit briefly redirects through the auth wall and returns to the app shell URL.
- That behavior blocks reliable production observation and can hide user-facing access failures.

## What
- Switched default fetch in `streamlit_access` to use `requests` with redirect history capture.
- Added redirect-history parsing so auth-wall/login hops are detected even when final URL looks healthy.
- Kept backward compatibility for existing 4-tuple custom fetch stubs.
- Added regression test covering auth-wall redirect history recovery case.

## Validation
- `pytest -q tests/test_streamlit_access.py`
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
