### PR TITLE
Fix #82: add remediation hints for streamlit access failures

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -134,6 +134,7 @@ python3 -m src.ingestion.cli streamlit-access-check --url https://finance-flow-l
 Expected behavior:
 - Exit code `0`: app shell reachable and no Streamlit auth-wall redirect detected.
 - Exit code `2`: access contract broken (e.g., redirected to `https://share.streamlit.io/-/auth/app`).
+- JSON output includes `remediation_hint` for non-OK results to guide immediate operator action.
 
 Operational response when check fails:
 1. Verify Streamlit app visibility/access policy in deployment settings.

--- a/src/ingestion/streamlit_access.py
+++ b/src/ingestion/streamlit_access.py
@@ -34,6 +34,19 @@ class AccessCheckResult:
             return "critical"
         return "warning"
 
+    @property
+    def remediation_hint(self) -> str | None:
+        if self.ok:
+            return None
+        if self.auth_wall_redirect:
+            return (
+                "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public "
+                "(or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"
+            )
+        if self.reason.startswith("network_error:"):
+            return "network_error: rerun with retries/backoff and confirm endpoint/network health"
+        return "unexpected_response: verify dashboard shell is reachable and Streamlit app is serving expected HTML"
+
     def to_dict(self) -> dict[str, object]:
         return {
             "ok": self.ok,
@@ -43,6 +56,7 @@ class AccessCheckResult:
             "reason": self.reason,
             "alert": self.alert,
             "alert_severity": self.alert_severity,
+            "remediation_hint": self.remediation_hint,
         }
 
 

--- a/tests/test_streamlit_access.py
+++ b/tests/test_streamlit_access.py
@@ -162,7 +162,7 @@ def test_check_streamlit_access_does_not_retry_auth_wall_failures():
     assert result.reason == "auth_wall_redirect_detected"
 
 
-def test_access_check_result_serializes_alert_fields():
+def test_access_check_result_serializes_alert_fields_with_remediation_hint():
     result = streamlit_access.AccessCheckResult(
         ok=False,
         status_code=303,
@@ -175,3 +175,21 @@ def test_access_check_result_serializes_alert_fields():
 
     assert payload["alert"] is True
     assert payload["alert_severity"] == "critical"
+    assert isinstance(payload["remediation_hint"], str)
+    assert "auth_wall_detected" in payload["remediation_hint"]
+
+
+def test_access_check_result_success_has_no_remediation_hint():
+    result = streamlit_access.AccessCheckResult(
+        ok=True,
+        status_code=200,
+        final_url="https://finance-flow-labs.streamlit.app/",
+        auth_wall_redirect=False,
+        reason="ok",
+    )
+
+    payload = result.to_dict()
+
+    assert payload["alert"] is False
+    assert payload["alert_severity"] == "none"
+    assert payload["remediation_hint"] is None


### PR DESCRIPTION
## Why
Issue #82 requests explicit operator guidance when auth-wall redirects break dashboard accessibility checks.

## What
- Added  field to  JSON payload.
- Included reason-specific guidance:
  - auth wall redirect
  - transient network errors
  - unexpected non-shell responses
- Extended unit tests to validate remediation hint behavior for failure/success cases.
- Updated ingestion runbook to document remediation hint presence.

## Validation
- ........................................................................ [ 65%]
......................................                                   [100%]
110 passed in 0.35s (110 passed)
