### PR TITLE
Fix #82: add post-deploy Streamlit access gate

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -126,6 +126,7 @@ Validation guardrails:
 ### Dashboard access contract smoke check
 
 Run from CI or post-deploy:
+- Recommended gate command: `./scripts/post_deploy_verify.sh` (non-zero exit means deploy verification failed)
 
 ```bash
 python3 -m src.ingestion.cli streamlit-access-check --url https://finance-flow-labs.streamlit.app/

--- a/scripts/post_deploy_verify.sh
+++ b/scripts/post_deploy_verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-https://finance-flow-labs.streamlit.app/}"
+
+echo "[post-deploy-verify] streamlit access contract check: $URL"
+./scripts/streamlit_access_smoke_check.sh "$URL"
+
+echo "[post-deploy-verify] ok"


### PR DESCRIPTION
## Why
Issue #82 requires an explicit deploy verification gate that fails when Streamlit access is redirected behind auth wall.

## What
- Added [post-deploy-verify] streamlit access contract check: https://finance-flow-labs.streamlit.app/
{"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"} as canonical post-deploy gate wrapper.
  - Runs {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}
  - Exits non-zero on auth-wall/unexpected failures to block deploy verification.
- Updated  to reference this gate command in CI/post-deploy flow.

## Validation
- ........................................................................ [ 65%]
......................................                                   [100%]
110 passed in 0.35s
  - 110 passed

## Notes
- Access checker logic + remediation hints remain unchanged and already covered by unit tests.
- HARD/SOFT evidence separation unchanged.

Closes #82.