### PR TITLE
fix: mark benchmark series stale at policy threshold boundary

### DIFF
--- a/src/ingestion/dashboard_service.py
+++ b/src/ingestion/dashboard_service.py
@@ -429,7 +429,7 @@ def _build_policy_compliance(
                 continue
             age_days = max(0, int((latest_run_dt - as_of_dt).total_seconds() // 86400))
             stale_age_days[key] = age_days
-            if age_days > max_stale_days:
+            if age_days >= max_stale_days:
                 stale_keys.append(key)
 
     if missing_keys:
@@ -438,7 +438,7 @@ def _build_policy_compliance(
     elif stale_keys:
         benchmark_status = "WARN"
         benchmark_reason = (
-            f"Stale benchmark series (>{max_stale_days}d): {', '.join(sorted(stale_keys))}"
+            f"Stale benchmark series (>={max_stale_days}d): {', '.join(sorted(stale_keys))}"
         )
     else:
         benchmark_status = "PASS"


### PR DESCRIPTION
## Why
Policy staleness checks should treat benchmark data that is exactly at the configured stale-day threshold as stale, not only values above it. This prevents borderline stale data from being incorrectly reported as healthy.

## What
- Changed benchmark staleness condition from  to  in policy compliance checks.
- Updated stale reason text to show the inclusive threshold ().
- Added regression test for the exact-threshold boundary ().

## Validation
- ............                                                             [100%]
12 passed in 0.03s
- ........................................................................ [ 64%]
........................................                                 [100%]
112 passed in 0.36s