### PR TITLE
feat(stock-analysis): add FMP valuation/consensus data path

### DIFF
--- a/.claude/skills/stock-analysis/SKILL.md
+++ b/.claude/skills/stock-analysis/SKILL.md
@@ -28,7 +28,7 @@ python3 -m src.analysis.cli stock edgar "Apple"
 
 검색 결과에서 회사명, 티커, corp_code(KR) 또는 CIK(US)를 확인하라.
 
-#### 1-2. 재무제표 수집
+#### 1-2. 재무제표/밸류에이션 수집
 
 ```bash
 # 한국: 최근 2개년 재무제표 (corp_code 또는 티커)
@@ -37,7 +37,14 @@ python3 -m src.analysis.cli stock dart "005930" --year 2023
 
 # 미국: XBRL company facts (티커 또는 CIK)
 python3 -m src.analysis.cli stock edgar "AAPL"
+
+# 미국(선택): 주가/멀티플/컨센서스(FMP)
+# 필요 ENV: FMP_API_KEY
+python3 -m src.analysis.cli stock fmp "AAPL" --limit 5
 ```
+
+> FMP 호출이 401/403 또는 플랜 제한으로 실패해도 분석을 중단하지 말고,
+> EDGAR + 뉴스 + 거시 데이터 기반으로 계속 진행하라. FMP 미수집 항목은 Needs Data에 명시하라.
 
 #### 1-3. 주식 관련 뉴스 수집
 

--- a/tests/test_analysis_cli.py
+++ b/tests/test_analysis_cli.py
@@ -1,0 +1,37 @@
+import argparse
+import json
+
+import src.analysis.cli as analysis_cli
+
+
+def test_analysis_cli_exposes_stock_fmp_subcommand() -> None:
+    parser = analysis_cli.build_parser()
+    args = parser.parse_args(["stock", "fmp", "GOOGL"])
+
+    assert args.command == "stock"
+    assert args.market == "fmp"
+    assert args.query == "GOOGL"
+    assert args.limit == 5
+
+
+def test_cmd_stock_fmp_uses_fmp_client(monkeypatch, capsys) -> None:
+    class FakeFmpClient:
+        def fetch_snapshot(self, query: str, limit: int):
+            assert query == "GOOGL"
+            assert limit == 7
+            return {
+                "query": query,
+                "symbol": "GOOGL",
+                "quote": {"price": 180.0},
+                "errors": [],
+            }
+
+    monkeypatch.setattr(analysis_cli, "FmpStockClient", FakeFmpClient)
+
+    args = argparse.Namespace(market="fmp", query="GOOGL", limit=7, year=None)
+    analysis_cli.cmd_stock(args)
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert payload["symbol"] == "GOOGL"
+    assert payload["quote"]["price"] == 180.0

--- a/tests/test_analysis_stock_client.py
+++ b/tests/test_analysis_stock_client.py
@@ -1,0 +1,81 @@
+import pytest
+
+from src.analysis.stock_client import FmpStockClient
+
+
+def test_fmp_stock_client_reports_missing_key_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FMP_API_KEY", raising=False)
+    client = FmpStockClient()
+
+    snapshot = client.fetch_snapshot("GOOGL")
+
+    assert snapshot["symbol"] == "GOOGL"
+    assert snapshot["quote"] == {}
+    assert snapshot["key_metrics"] == []
+    assert snapshot["analyst_estimates"] == []
+    assert snapshot["price_target_consensus"] == {}
+    assert snapshot["price_targets"] == []
+    assert any("FMP_API_KEY is not set" in err for err in snapshot["errors"])
+
+
+def test_fmp_stock_client_fetch_snapshot_aggregates_valuation_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FmpStockClient(api_key="test-key")
+
+    def fake_get(path: str, params: dict[str, str]):
+        if path == "/v3/search":
+            return [
+                {
+                    "symbol": "GOOGL",
+                    "name": "Alphabet Inc.",
+                    "exchangeShortName": "NASDAQ",
+                    "type": "stock",
+                }
+            ]
+        if path == "/v3/quote/GOOGL":
+            return [{"symbol": "GOOGL", "price": 181.25, "marketCap": 1_000_000_000}]
+        if path == "/v3/key-metrics/GOOGL":
+            assert params["limit"] == "3"
+            return [{"date": "2025-12-31", "peRatio": 24.5, "pbRatio": 7.2}]
+        if path == "/v3/analyst-estimates/GOOGL":
+            assert params["limit"] == "3"
+            return [{"date": "2026-12-31", "estimatedEpsAvg": 9.8}]
+        if path == "/v4/price-target-consensus":
+            return [{"symbol": "GOOGL", "targetConsensus": 210.0, "targetHigh": 250.0}]
+        if path == "/v4/price-target":
+            assert params["limit"] == "3"
+            return [{"symbol": "GOOGL", "publishedDate": "2026-02-01", "priceTarget": 220.0}]
+        raise AssertionError(f"Unexpected path: {path}")
+
+    monkeypatch.setattr(client, "_get", fake_get)
+
+    snapshot = client.fetch_snapshot("Google", limit=3)
+
+    assert snapshot["symbol"] == "GOOGL"
+    assert snapshot["companies"][0]["name"] == "Alphabet Inc."
+    assert snapshot["quote"]["price"] == 181.25
+    assert snapshot["key_metrics"][0]["peRatio"] == 24.5
+    assert snapshot["analyst_estimates"][0]["estimatedEpsAvg"] == 9.8
+    assert snapshot["price_target_consensus"]["targetConsensus"] == 210.0
+    assert snapshot["price_targets"][0]["priceTarget"] == 220.0
+    assert snapshot["errors"] == []
+
+
+def test_fmp_stock_client_collects_non_fatal_endpoint_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FmpStockClient(api_key="test-key")
+
+    def fake_get(path: str, params: dict[str, str]):
+        if path == "/v3/search":
+            return []
+        if path.startswith("/v3/quote/"):
+            raise ValueError("FMP HTTP 403 for /v3/quote")
+        return []
+
+    monkeypatch.setattr(client, "_get", fake_get)
+
+    snapshot = client.fetch_snapshot("GOOGL", limit=2)
+
+    assert snapshot["symbol"] == "GOOGL"
+    assert snapshot["quote"] == {}
+    assert any("quote" in err for err in snapshot["errors"])


### PR DESCRIPTION
## Why
`stock-analysis` 결과에서 Value 섹션 핵심 근거(주가/멀티플/컨센서스)가 비어 있었습니다. 현재 분석 CLI는 DART/EDGAR만 지원하고 FMP를 호출하지 않아, 밸류에이션 데이터가 파이프라인에 들어오지 않았습니다.

## What
- `src/analysis/stock_client.py`
  - `FmpStockClient` 신규 추가
  - FMP v3/v4 엔드포인트 통합 스냅샷 지원:
    - search
    - quote
    - key-metrics
    - analyst-estimates
    - price-target-consensus
    - price-target
  - 401/403/플랜 제한 등 실패 시 non-fatal `errors[]`로 수집하고 계속 진행하도록 설계
- `src/analysis/cli.py`
  - `stock fmp <query> --limit N` 서브커맨드 추가
  - stock 명령 라우팅에 FMP 경로 추가
- `.claude/skills/stock-analysis/SKILL.md`
  - Step 1-2에 FMP 수집 명령 추가
  - FMP 제한(401/403) 발생 시 분석 중단하지 않고 Needs Data로 표기하도록 가드레일 명시
- Tests
  - `tests/test_analysis_stock_client.py`
    - FMP key 없음 fallback/error 표출 검증
    - 스냅샷 집계 필드 검증
    - 단일 endpoint 실패 시 non-fatal 동작 검증
  - `tests/test_analysis_cli.py`
    - `stock fmp` parser 노출 검증
    - `cmd_stock` FMP 라우팅 검증

## Validation
- `pytest -q tests/test_analysis_cli.py tests/test_analysis_stock_client.py`
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Manual smoke:
  - `python3 -m src.analysis.cli stock fmp GOOGL --limit 2`
  - FMP 403 환경에서도 JSON + errors 필드로 정상 종료 확인
