### PR TITLE
[portfolio] Add composite benchmark return service

### DIFF
--- a/src/enduser/__init__.py
+++ b/src/enduser/__init__.py
@@ -1,0 +1,1 @@
+"""End-user facing services for portfolio/benchmark views."""

--- a/src/enduser/benchmark_service.py
+++ b/src/enduser/benchmark_service.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from datetime import date, datetime
+
+BENCHMARK_COMPONENTS: tuple[str, ...] = ("QQQ", "KOSPI200", "BTC", "SGOV")
+DEFAULT_BENCHMARK_WEIGHTS: dict[str, float] = {
+    "QQQ": 0.45,
+    "KOSPI200": 0.25,
+    "BTC": 0.20,
+    "SGOV": 0.10,
+}
+WEIGHT_ENV_MAP: dict[str, str] = {
+    "QQQ": "BENCHMARK_WEIGHT_QQQ",
+    "KOSPI200": "BENCHMARK_WEIGHT_KOSPI200",
+    "BTC": "BENCHMARK_WEIGHT_BTC",
+    "SGOV": "BENCHMARK_WEIGHT_SGOV",
+}
+
+
+def _parse_as_of(raw: object) -> date | None:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, date):
+        return raw
+    text = str(raw).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text).date()
+    except ValueError:
+        return None
+
+
+def _load_weights() -> dict[str, float]:
+    weights = dict(DEFAULT_BENCHMARK_WEIGHTS)
+    for key, env_name in WEIGHT_ENV_MAP.items():
+        raw = os.getenv(env_name)
+        if raw is None or raw.strip() == "":
+            continue
+        try:
+            weights[key] = float(raw)
+        except ValueError:
+            continue
+    return weights
+
+
+def _build_daily_levels(repository: object, metric_key: str) -> dict[date, float]:
+    rows = repository.read_macro_series_points(metric_key, limit=10_000)
+    levels: dict[date, float] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        day = _parse_as_of(row.get("as_of"))
+        if day is None or day in levels:
+            continue
+        value = row.get("value")
+        try:
+            levels[day] = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+    return levels
+
+
+def _build_daily_returns(levels: dict[date, float]) -> dict[date, float]:
+    returns: dict[date, float] = {}
+    ordered_days = sorted(levels.keys())
+    for idx in range(1, len(ordered_days)):
+        prev_day = ordered_days[idx - 1]
+        day = ordered_days[idx]
+        prev_value = levels[prev_day]
+        current_value = levels[day]
+        if prev_value == 0:
+            continue
+        returns[day] = (current_value / prev_value) - 1.0
+    return returns
+
+
+def compute_benchmark_series(repository: object, start_date: object, end_date: object) -> list[dict[str, object]]:
+    """Compute weighted daily return / indexed NAV series for policy benchmark.
+
+    Returns [{as_of, benchmark_return, benchmark_nav}, ...] for dates where all
+    benchmark components have an available daily return.
+    """
+
+    start = _parse_as_of(start_date)
+    end = _parse_as_of(end_date)
+    if start is None or end is None or start > end:
+        return []
+
+    weights = _load_weights()
+    per_component_returns: dict[str, dict[date, float]] = {}
+    for metric_key in BENCHMARK_COMPONENTS:
+        levels = _build_daily_levels(repository, metric_key)
+        per_component_returns[metric_key] = _build_daily_returns(levels)
+
+    if not per_component_returns:
+        return []
+
+    common_dates: set[date] | None = None
+    for metric_key in BENCHMARK_COMPONENTS:
+        metric_dates = set(per_component_returns[metric_key].keys())
+        common_dates = metric_dates if common_dates is None else common_dates & metric_dates
+
+    if not common_dates:
+        return []
+
+    nav = 1.0
+    series: list[dict[str, object]] = []
+    for day in sorted(common_dates):
+        if day < start or day > end:
+            continue
+        benchmark_return = 0.0
+        for metric_key in BENCHMARK_COMPONENTS:
+            benchmark_return += weights.get(metric_key, 0.0) * per_component_returns[metric_key][day]
+        nav *= 1.0 + benchmark_return
+        series.append(
+            {
+                "as_of": day.isoformat(),
+                "benchmark_return": benchmark_return,
+                "benchmark_nav": nav,
+            }
+        )
+
+    return series

--- a/tests/test_benchmark_service.py
+++ b/tests/test_benchmark_service.py
@@ -1,0 +1,112 @@
+import math
+
+from src.enduser.benchmark_service import compute_benchmark_series
+
+
+class FakeBenchmarkRepository:
+    def __init__(self, metric_rows):
+        self.metric_rows = metric_rows
+
+    def read_macro_series_points(self, metric_key, limit=10000):
+        rows = self.metric_rows.get(metric_key, [])
+        return rows[:limit]
+
+
+def test_compute_benchmark_series_returns_weighted_daily_return_and_nav(monkeypatch):
+    monkeypatch.delenv("BENCHMARK_WEIGHT_QQQ", raising=False)
+    monkeypatch.delenv("BENCHMARK_WEIGHT_KOSPI200", raising=False)
+    monkeypatch.delenv("BENCHMARK_WEIGHT_BTC", raising=False)
+    monkeypatch.delenv("BENCHMARK_WEIGHT_SGOV", raising=False)
+
+    repo = FakeBenchmarkRepository(
+        {
+            "QQQ": [
+                {"as_of": "2026-02-20", "value": 101.0},
+                {"as_of": "2026-02-19", "value": 100.0},
+            ],
+            "KOSPI200": [
+                {"as_of": "2026-02-20", "value": 201.0},
+                {"as_of": "2026-02-19", "value": 200.0},
+            ],
+            "BTC": [
+                {"as_of": "2026-02-20", "value": 51000.0},
+                {"as_of": "2026-02-19", "value": 50000.0},
+            ],
+            "SGOV": [
+                {"as_of": "2026-02-20", "value": 100.2},
+                {"as_of": "2026-02-19", "value": 100.0},
+            ],
+        }
+    )
+
+    rows = compute_benchmark_series(repo, "2026-02-19", "2026-02-20")
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["as_of"] == "2026-02-20"
+
+    expected_return = (
+        0.45 * (101.0 / 100.0 - 1.0)
+        + 0.25 * (201.0 / 200.0 - 1.0)
+        + 0.20 * (51000.0 / 50000.0 - 1.0)
+        + 0.10 * (100.2 / 100.0 - 1.0)
+    )
+    assert math.isclose(row["benchmark_return"], expected_return, rel_tol=1e-12)
+    assert math.isclose(row["benchmark_nav"], 1.0 + expected_return, rel_tol=1e-12)
+
+
+def test_compute_benchmark_series_honors_env_weight_override(monkeypatch):
+    monkeypatch.setenv("BENCHMARK_WEIGHT_QQQ", "1.0")
+    monkeypatch.setenv("BENCHMARK_WEIGHT_KOSPI200", "0")
+    monkeypatch.setenv("BENCHMARK_WEIGHT_BTC", "0")
+    monkeypatch.setenv("BENCHMARK_WEIGHT_SGOV", "0")
+
+    repo = FakeBenchmarkRepository(
+        {
+            "QQQ": [
+                {"as_of": "2026-02-20", "value": 110.0},
+                {"as_of": "2026-02-19", "value": 100.0},
+            ],
+            "KOSPI200": [
+                {"as_of": "2026-02-20", "value": 500.0},
+                {"as_of": "2026-02-19", "value": 1.0},
+            ],
+            "BTC": [
+                {"as_of": "2026-02-20", "value": 500.0},
+                {"as_of": "2026-02-19", "value": 1.0},
+            ],
+            "SGOV": [
+                {"as_of": "2026-02-20", "value": 500.0},
+                {"as_of": "2026-02-19", "value": 1.0},
+            ],
+        }
+    )
+
+    rows = compute_benchmark_series(repo, "2026-02-19", "2026-02-20")
+
+    assert len(rows) == 1
+    assert math.isclose(rows[0]["benchmark_return"], 0.10, rel_tol=1e-12)
+    assert math.isclose(rows[0]["benchmark_nav"], 1.10, rel_tol=1e-12)
+
+
+def test_compute_benchmark_series_skips_when_component_series_missing():
+    repo = FakeBenchmarkRepository(
+        {
+            "QQQ": [
+                {"as_of": "2026-02-20", "value": 101.0},
+                {"as_of": "2026-02-19", "value": 100.0},
+            ],
+            "KOSPI200": [
+                {"as_of": "2026-02-20", "value": 201.0},
+                {"as_of": "2026-02-19", "value": 200.0},
+            ],
+            "BTC": [
+                {"as_of": "2026-02-20", "value": 51000.0},
+                {"as_of": "2026-02-19", "value": 50000.0},
+            ],
+            "SGOV": [{"as_of": "2026-02-20", "value": 100.2}],
+        }
+    )
+
+    rows = compute_benchmark_series(repo, "2026-02-19", "2026-02-20")
+    assert rows == []


### PR DESCRIPTION
## Why
Portfolio performance comparison requires policy-locked composite benchmark returns (QQQ/KOSPI200/BTC/SGOV) computed from HARD macro series points.

## What
- Added `src/enduser/benchmark_service.py`
  - `compute_benchmark_series(repository, start_date, end_date) -> list[dict]`
  - returns rows as `{as_of, benchmark_return, benchmark_nav}`
- Implemented policy default benchmark weights with env overrides:
  - `BENCHMARK_WEIGHT_QQQ` (default 0.45)
  - `BENCHMARK_WEIGHT_KOSPI200` (default 0.25)
  - `BENCHMARK_WEIGHT_BTC` (default 0.20)
  - `BENCHMARK_WEIGHT_SGOV` (default 0.10)
- Added unit tests for:
  - weighted daily return + NAV calculation
  - env override behavior
  - missing component handling (no partial soft fill)

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (121 passed)

Closes #95
