### PR TITLE
fix(fmp): switch stock valuation client to stable APIs

### DIFF
--- a/tests/test_analysis_stock_client.py
+++ b/tests/test_analysis_stock_client.py
@@ -9,11 +9,13 @@ def test_fmp_stock_client_reports_missing_key_as_error(monkeypatch: pytest.Monke
 
     snapshot = client.fetch_snapshot("GOOGL")
 
+    assert snapshot["endpoint_family"] == "stable"
     assert snapshot["symbol"] == "GOOGL"
     assert snapshot["quote"] == {}
     assert snapshot["key_metrics"] == []
     assert snapshot["analyst_estimates"] == []
     assert snapshot["price_target_consensus"] == {}
+    assert snapshot["price_target_summary"] == {}
     assert snapshot["price_targets"] == []
     assert any("FMP_API_KEY is not set" in err for err in snapshot["errors"])
 
@@ -24,41 +26,47 @@ def test_fmp_stock_client_fetch_snapshot_aggregates_valuation_payloads(
     client = FmpStockClient(api_key="test-key")
 
     def fake_get(path: str, params: dict[str, str]):
-        if path == "/v3/search":
+        if path == "/stable/search-symbol":
             return [
                 {
                     "symbol": "GOOGL",
                     "name": "Alphabet Inc.",
-                    "exchangeShortName": "NASDAQ",
+                    "exchange": "NASDAQ",
+                    "exchangeFullName": "NASDAQ Global Select",
                     "type": "stock",
+                    "currency": "USD",
                 }
             ]
-        if path == "/v3/quote/GOOGL":
+        if path == "/stable/quote":
+            assert params["symbol"] == "GOOGL"
             return [{"symbol": "GOOGL", "price": 181.25, "marketCap": 1_000_000_000}]
-        if path == "/v3/key-metrics/GOOGL":
-            assert params["limit"] == "3"
+        if path == "/stable/key-metrics":
+            assert params["symbol"] == "GOOGL"
             return [{"date": "2025-12-31", "peRatio": 24.5, "pbRatio": 7.2}]
-        if path == "/v3/analyst-estimates/GOOGL":
+        if path == "/stable/analyst-estimates":
+            assert params["symbol"] == "GOOGL"
+            assert params["period"] == "annual"
             assert params["limit"] == "3"
-            return [{"date": "2026-12-31", "estimatedEpsAvg": 9.8}]
-        if path == "/v4/price-target-consensus":
+            return [{"date": "2026-12-31", "epsAvg": 9.8}]
+        if path == "/stable/price-target-consensus":
             return [{"symbol": "GOOGL", "targetConsensus": 210.0, "targetHigh": 250.0}]
-        if path == "/v4/price-target":
-            assert params["limit"] == "3"
-            return [{"symbol": "GOOGL", "publishedDate": "2026-02-01", "priceTarget": 220.0}]
+        if path == "/stable/price-target-summary":
+            return [{"symbol": "GOOGL", "allTimeAvgPriceTarget": 220.0}]
         raise AssertionError(f"Unexpected path: {path}")
 
     monkeypatch.setattr(client, "_get", fake_get)
 
     snapshot = client.fetch_snapshot("Google", limit=3)
 
+    assert snapshot["endpoint_family"] == "stable"
     assert snapshot["symbol"] == "GOOGL"
     assert snapshot["companies"][0]["name"] == "Alphabet Inc."
     assert snapshot["quote"]["price"] == 181.25
     assert snapshot["key_metrics"][0]["peRatio"] == 24.5
-    assert snapshot["analyst_estimates"][0]["estimatedEpsAvg"] == 9.8
+    assert snapshot["analyst_estimates"][0]["epsAvg"] == 9.8
     assert snapshot["price_target_consensus"]["targetConsensus"] == 210.0
-    assert snapshot["price_targets"][0]["priceTarget"] == 220.0
+    assert snapshot["price_target_summary"]["allTimeAvgPriceTarget"] == 220.0
+    assert snapshot["price_targets"][0]["allTimeAvgPriceTarget"] == 220.0
     assert snapshot["errors"] == []
 
 
@@ -66,10 +74,12 @@ def test_fmp_stock_client_collects_non_fatal_endpoint_errors(monkeypatch: pytest
     client = FmpStockClient(api_key="test-key")
 
     def fake_get(path: str, params: dict[str, str]):
-        if path == "/v3/search":
+        if path == "/stable/search-symbol":
             return []
-        if path.startswith("/v3/quote/"):
-            raise ValueError("FMP HTTP 403 for /v3/quote")
+        if path == "/stable/search-name":
+            return []
+        if path == "/stable/quote":
+            raise ValueError("FMP HTTP 403 for /stable/quote")
         return []
 
     monkeypatch.setattr(client, "_get", fake_get)


### PR DESCRIPTION
## Why
FMP integration added in #92 was using legacy `/api/v3` and `/api/v4` endpoints.
FMP now returns `403 Legacy Endpoint` for these routes (non-legacy subscribers), so valuation/consensus payloads stayed empty.

## What
- `src/analysis/stock_client.py`
  - Migrated `FmpStockClient.fetch_snapshot()` to **stable** endpoints:
    - `/stable/search-symbol` (fallback `/stable/search-name`)
    - `/stable/quote`
    - `/stable/key-metrics`
    - `/stable/analyst-estimates`
    - `/stable/price-target-consensus`
    - `/stable/price-target-summary`
  - Added `endpoint_family: "stable"` in output for diagnostics.
  - Added `price_target_summary` field while keeping `price_targets` compatibility alias.
  - Added exact-symbol preference when resolving symbol from search results.
- `tests/test_analysis_stock_client.py`
  - Updated test fixtures to stable endpoints and stable field names (`epsAvg`, etc.).
  - Added assertions for `endpoint_family` and `price_target_summary`.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` → **121 passed**
- Manual smoke:
  - `python3 -m src.analysis.cli stock fmp GOOGL --limit 2`
  - Verified live payload now includes quote/key_metrics/analyst_estimates/price_target_consensus with `errors: []`.
