### PR TITLE
[dashboard] add deployed accessibility incident banner + degraded guidance

### DIFF
--- a/src/ingestion/streamlit_access.py
+++ b/src/ingestion/streamlit_access.py
@@ -143,10 +143,8 @@ def _check_streamlit_access_once(
         next_url = urljoin(url, location)
         auth_wall_from_location = _is_auth_wall_url(next_url)
 
-    # Streamlit Community Cloud may transiently bounce through auth endpoints even for public apps.
-    # Treat auth wall as fatal only when the final response is still an auth/login endpoint or when
-    # the current response explicitly points to auth wall via Location header.
-    auth_wall_redirect = auth_wall_final_url or auth_wall_from_location
+    # Treat any auth wall evidence in redirect chain as a critical accessibility regression.
+    auth_wall_redirect = auth_wall_final_url or auth_wall_from_location or auth_wall_seen_in_history
 
     if auth_wall_redirect:
         return AccessCheckResult(

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -379,3 +379,25 @@ def test_dashboard_app_marks_non_finite_numbers_as_error_not_crash():
     assert cards["hard_evidence_pct"] == "n/a"
     assert cards["metric_status"]["raw_events"]["status"] == "error"
     assert cards["metric_status"]["coverage_pct"]["reason"] == "non_finite_numeric"
+
+
+def test_dashboard_app_flags_deployed_access_incident_when_degraded():
+    cards = dashboard_app.build_operator_cards(
+        {
+            "deployed_access": {
+                "status": "degraded",
+                "reason": "auth_wall_redirect_detected",
+                "checked_at": "2026-02-22T15:00:00Z",
+                "remediation_hint": "set app public",
+            }
+        }
+    )
+
+    assert cards["has_deployed_access_alert"] is True
+    assert cards["deployed_access"]["reason"] == "auth_wall_redirect_detected"
+
+
+def test_dashboard_app_keeps_deployed_access_alert_off_when_status_ok():
+    cards = dashboard_app.build_operator_cards({"deployed_access": {"status": "ok"}})
+
+    assert cards["has_deployed_access_alert"] is False


### PR DESCRIPTION
## Why\n- Resolve #93 by surfacing deployed accessibility status in dashboard state.\n- Make auth-wall/degraded incidents visible to operators with immediate next-step guidance.\n\n## What\n- Add  block to dashboard view model from  payload (status/reason/checked_at/remediation_hint).\n- Render critical incident banner + degraded-mode guidance in Streamlit UI when status is degraded/auth-wall.\n- Add regression tests for service/app mapping.\n- Tighten streamlit access detection so auth-wall seen in redirect history is treated as critical again (keeps existing contract test green).\n\n## Validation\n- .............................                                            [100%]
29 passed in 0.06s\n- ........................................................................ [ 57%]
......................................................                   [100%]
126 passed in 0.43s\n