### PR TITLE
Fix #111: enforce deploy access mode gate for Streamlit auth-wall regressions

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -129,13 +129,25 @@ Run from CI or post-deploy:
 - Recommended gate command: `./scripts/post_deploy_verify.sh` (non-zero exit means deploy verification failed)
 
 ```bash
-python3 -m src.ingestion.cli streamlit-access-check --url https://finance-flow-labs.streamlit.app/
+python3 -m src.ingestion.cli deploy-access-gate \
+  --url https://finance-flow-labs.streamlit.app/ \
+  --mode public
 ```
 
+Access policy:
+- `DEPLOY_ACCESS_MODE=public` (default): Streamlit auth wall is a **hard release blocker**.
+- `DEPLOY_ACCESS_MODE=restricted`: auth wall is allowed **only** when `DEPLOY_RESTRICTED_LOGIN_PATH` (or `--restricted-login-path`) is provided.
+
 Expected behavior:
-- Exit code `0`: app shell reachable and no Streamlit auth-wall redirect detected.
-- Exit code `2`: access contract broken (e.g., redirected to `https://share.streamlit.io/-/auth/app`).
-- JSON output includes `remediation_hint` for non-OK results to guide immediate operator action.
+- Exit code `0`: deploy gate passed for the selected access mode.
+- Exit code `2`: deploy gate failed (release blocker).
+- JSON output includes structured payload:
+  - `access_check.reason`
+  - `access_check.alert_severity`
+  - `access_check.remediation_hint`
+  - `gate.reason`
+  - `gate.severity`
+  - `gate.operator_message`
 
 Operational response when check fails:
 1. Verify Streamlit app visibility/access policy in deployment settings.

--- a/scripts/streamlit_access_smoke_check.sh
+++ b/scripts/streamlit_access_smoke_check.sh
@@ -5,9 +5,20 @@ URL="${1:-https://finance-flow-labs.streamlit.app/}"
 ATTEMPTS="${ATTEMPTS:-3}"
 BACKOFF_SECONDS="${BACKOFF_SECONDS:-0.5}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-15}"
+DEPLOY_ACCESS_MODE="${DEPLOY_ACCESS_MODE:-public}"
+DEPLOY_RESTRICTED_LOGIN_PATH="${DEPLOY_RESTRICTED_LOGIN_PATH:-}"
 
-python3 -m src.ingestion.cli streamlit-access-check \
-  --url "$URL" \
-  --attempts "$ATTEMPTS" \
-  --backoff-seconds "$BACKOFF_SECONDS" \
+cmd=(
+  python3 -m src.ingestion.cli deploy-access-gate
+  --url "$URL"
+  --mode "$DEPLOY_ACCESS_MODE"
+  --attempts "$ATTEMPTS"
+  --backoff-seconds "$BACKOFF_SECONDS"
   --timeout-seconds "$TIMEOUT_SECONDS"
+)
+
+if [[ -n "$DEPLOY_RESTRICTED_LOGIN_PATH" ]]; then
+  cmd+=(--restricted-login-path "$DEPLOY_RESTRICTED_LOGIN_PATH")
+fi
+
+"${cmd[@]}"

--- a/src/ingestion/deploy_access_policy.py
+++ b/src/ingestion/deploy_access_policy.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+ALLOWED_MODES = {"public", "restricted"}
+
+
+@dataclass(frozen=True)
+class DeployAccessDecision:
+    ok: bool
+    mode: str
+    release_blocker: bool
+    reason: str
+    severity: str
+    operator_message: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "mode": self.mode,
+            "release_blocker": self.release_blocker,
+            "reason": self.reason,
+            "severity": self.severity,
+            "operator_message": self.operator_message,
+        }
+
+
+def normalize_access_mode(mode: str | None) -> str:
+    normalized = (mode or "public").strip().lower()
+    if normalized not in ALLOWED_MODES:
+        raise ValueError(f"DEPLOY_ACCESS_MODE must be one of {sorted(ALLOWED_MODES)}")
+    return normalized
+
+
+def evaluate_deploy_access(
+    access_result: dict[str, object],
+    *,
+    mode: str,
+    restricted_login_path: str | None = None,
+) -> DeployAccessDecision:
+    access_mode = normalize_access_mode(mode)
+
+    ok = bool(access_result.get("ok"))
+    auth_wall_redirect = bool(access_result.get("auth_wall_redirect"))
+    reason = str(access_result.get("reason") or "unknown")
+
+    if access_mode == "public":
+        if ok:
+            return DeployAccessDecision(
+                ok=True,
+                mode=access_mode,
+                release_blocker=False,
+                reason="ok",
+                severity="none",
+                operator_message="Public mode validated: dashboard shell reachable without auth wall.",
+            )
+
+        severity = "critical" if auth_wall_redirect else "warning"
+        return DeployAccessDecision(
+            ok=False,
+            mode=access_mode,
+            release_blocker=True,
+            reason=reason,
+            severity=severity,
+            operator_message=(
+                "Public mode violation: unauthenticated dashboard access failed. "
+                "Set Streamlit visibility to Public, redeploy, and rerun gate."
+            ),
+        )
+
+    # restricted mode
+    if ok:
+        return DeployAccessDecision(
+            ok=True,
+            mode=access_mode,
+            release_blocker=False,
+            reason="ok",
+            severity="none",
+            operator_message="Restricted mode validated with reachable dashboard shell.",
+        )
+
+    if auth_wall_redirect and restricted_login_path:
+        return DeployAccessDecision(
+            ok=True,
+            mode=access_mode,
+            release_blocker=False,
+            reason="restricted_auth_required",
+            severity="info",
+            operator_message=(
+                "Restricted mode active: auth wall detected as expected. "
+                f"Operator login path: {restricted_login_path}"
+            ),
+        )
+
+    return DeployAccessDecision(
+        ok=False,
+        mode=access_mode,
+        release_blocker=True,
+        reason="restricted_mode_login_path_missing" if auth_wall_redirect else reason,
+        severity="critical" if auth_wall_redirect else "warning",
+        operator_message=(
+            "Restricted mode requires documented operator login path when auth wall is detected."
+            if auth_wall_redirect
+            else "Restricted mode check failed for non-auth-wall reason. Investigate deployment health."
+        ),
+    )

--- a/tests/test_deploy_access_policy.py
+++ b/tests/test_deploy_access_policy.py
@@ -1,0 +1,51 @@
+import importlib
+
+
+deploy_access_policy = importlib.import_module("src.ingestion.deploy_access_policy")
+
+
+def test_public_mode_blocks_auth_wall_redirect():
+    decision = deploy_access_policy.evaluate_deploy_access(
+        {
+            "ok": False,
+            "auth_wall_redirect": True,
+            "reason": "auth_wall_redirect_detected",
+        },
+        mode="public",
+    )
+
+    assert decision.ok is False
+    assert decision.release_blocker is True
+    assert decision.reason == "auth_wall_redirect_detected"
+
+
+def test_restricted_mode_allows_auth_wall_with_documented_login_path():
+    decision = deploy_access_policy.evaluate_deploy_access(
+        {
+            "ok": False,
+            "auth_wall_redirect": True,
+            "reason": "auth_wall_redirect_detected",
+        },
+        mode="restricted",
+        restricted_login_path="https://share.streamlit.io/login",
+    )
+
+    assert decision.ok is True
+    assert decision.release_blocker is False
+    assert decision.reason == "restricted_auth_required"
+
+
+def test_restricted_mode_requires_documented_login_path_for_auth_wall():
+    decision = deploy_access_policy.evaluate_deploy_access(
+        {
+            "ok": False,
+            "auth_wall_redirect": True,
+            "reason": "auth_wall_redirect_detected",
+        },
+        mode="restricted",
+        restricted_login_path=None,
+    )
+
+    assert decision.ok is False
+    assert decision.release_blocker is True
+    assert decision.reason == "restricted_mode_login_path_missing"


### PR DESCRIPTION
## Why
Production entrypoint can silently regress into Streamlit auth-wall redirects, blocking end-user dashboard access. We need an explicit deployment access policy with release-blocking behavior in public mode.

## What
- added `src/ingestion/deploy_access_policy.py` for mode-aware gate decisions (`public|restricted`)
- added CLI command `deploy-access-gate` that wraps `streamlit-access-check` and applies policy
- upgraded smoke check script to run the deploy gate using `DEPLOY_ACCESS_MODE` and optional `DEPLOY_RESTRICTED_LOGIN_PATH`
- documented mode contract and structured gate output in runbook
- added tests for policy decisions and CLI gate wiring

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- result: `131 passed`

## Policy alignment
- preserves HARD/SOFT evidence separation (ops/deploy only change)
- establishes fail-fast release blocker for public-access contract
