### PR TITLE
fix(dashboard): handle comma-grouped count strings

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -153,11 +153,12 @@ def build_operator_cards(view: Mapping[str, object]) -> dict[str, object]:
                 return _metric("n/a", status="error", reason="non_finite_numeric")
             return _metric(int(value))
         if isinstance(value, str):
+            normalized = value.strip().replace(",", "")
             try:
-                return _metric(int(value))
+                return _metric(int(normalized))
             except ValueError:
                 try:
-                    parsed = float(value)
+                    parsed = float(normalized)
                 except ValueError:
                     return _metric("n/a", status="error", reason="invalid_numeric")
                 if not math.isfinite(parsed):

--- a/tests/test_dashboard_app_smoke.py
+++ b/tests/test_dashboard_app_smoke.py
@@ -197,6 +197,35 @@ def test_dashboard_app_parses_numeric_strings_for_percent_metrics():
     assert cards["evidence_gap_pct"] == "14.0%"
 
 
+def test_dashboard_app_parses_comma_grouped_integer_strings_for_count_metrics():
+    cards = dashboard_app.build_operator_cards(
+        {
+            "counters": {
+                "raw_events": "1,234",
+                "canonical_events": "2,000",
+                "quarantine_events": "10",
+            },
+            "learning_metrics": {
+                "forecast_count": "12,345",
+                "realized_count": "6,789",
+            },
+            "attribution_summary": {
+                "total": "1,111",
+                "top_count": "222",
+                "evidence_gap_count": "3",
+            },
+        }
+    )
+
+    assert cards["raw_events"] == 1234
+    assert cards["canonical_events"] == 2000
+    assert cards["forecast_count"] == 12345
+    assert cards["realized_count"] == 6789
+    assert cards["attribution_total"] == 1111
+    assert cards["attribution_top_count"] == 222
+    assert cards["metric_status"]["raw_events"]["status"] == "ok"
+
+
 def test_dashboard_app_flags_missing_required_horizon_metrics():
     cards = dashboard_app.build_operator_cards(
         {


### PR DESCRIPTION
## Why
Dashboard count metrics currently parse numeric strings but fail on common comma-grouped formats (e.g., `"1,234"`). This causes false `invalid_numeric` errors in user-facing cards even when data is valid.

## What
- Normalize string count metrics by stripping comma separators before integer/float parsing.
- Add regression test coverage for comma-grouped integer strings across counters, learning counts, and attribution counts.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
