### PR TITLE
fix(deploy): enforce structured deploy-access gate output for CI

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -185,3 +185,14 @@ Rollback steps (when a recent deployment introduced auth-wall regression):
   - Set `OUTPUT_JSON_PATH` to persist gate output JSON while keeping stdout logs.
   - Example: `OUTPUT_JSON_PATH=deploy_access_gate.json ./scripts/streamlit_access_smoke_check.sh`
   - Use captured payload fields for operator audit (`access_check.reason`, `access_check.alert_severity`, `access_check.remediation_hint`).
+
+### CI release gate helper
+
+- Script: `./scripts/deploy_access_gate_ci.sh`
+- Intended for CI/deploy runners to:
+  - print full JSON gate payload,
+  - emit structured summary (`mode`, `release_blocker`, `reason`, `severity`, `hint`),
+  - exit `2` when `gate.release_blocker=true`.
+- Persist outputs in pipeline artifacts/logs:
+  - raw stdout JSON (e.g., `deploy_access_gate.json`)
+  - generated summary file: `deploy_access_gate_summary.md`

--- a/scripts/deploy_access_gate_ci.sh
+++ b/scripts/deploy_access_gate_ci.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-https://finance-flow-labs.streamlit.app/}"
+MODE="${DEPLOY_ACCESS_MODE:-public}"
+LOGIN_PATH="${DEPLOY_RESTRICTED_LOGIN_PATH:-}"
+
+TMP_JSON="$(mktemp)"
+cleanup() {
+  rm -f "$TMP_JSON"
+}
+trap cleanup EXIT
+
+python3 -m src.ingestion.cli deploy-access-gate \
+  --url "$URL" \
+  --mode "$MODE" \
+  ${LOGIN_PATH:+--restricted-login-path "$LOGIN_PATH"} >"$TMP_JSON"
+
+cat "$TMP_JSON"
+
+python3 - "$TMP_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+access = payload.get("access_check", {})
+gate = payload.get("gate", {})
+
+reason = str(gate.get("reason") or access.get("reason") or "unknown")
+severity = str(gate.get("severity") or access.get("alert_severity") or "unknown")
+hint = str(gate.get("remediation_hint") or access.get("remediation_hint") or "")
+release_blocker = bool(gate.get("release_blocker"))
+mode = str(payload.get("deploy_access_mode") or "public")
+
+print(f"[deploy-access-gate] mode={mode} release_blocker={release_blocker} reason={reason} severity={severity}")
+if hint:
+    print(f"[deploy-access-gate] hint={hint}")
+
+summary_path = Path("deploy_access_gate_summary.md")
+summary_path.write_text(
+    "\n".join(
+        [
+            "## Deploy Access Gate",
+            f"- mode: `{mode}`",
+            f"- release_blocker: `{str(release_blocker).lower()}`",
+            f"- reason: `{reason}`",
+            f"- severity: `{severity}`",
+            f"- hint: {hint or '(none)' }",
+        ]
+    )
+    + "\n",
+    encoding="utf-8",
+)
+
+if release_blocker:
+    sys.exit(2)
+PY


### PR DESCRIPTION
## Why
Issue #111 requests an explicit deploy accessibility gate for Streamlit access mode with machine-readable failure context. We already have policy logic in CLI, but CI/deploy runners still lack a single helper that standardizes structured gate output and exit semantics.

## What
- add 
  - runs 
  - prints full JSON payload for audit logs
  - emits normalized summary fields (, , , , )
  - writes 
  - exits with code  when release blocker is true
- update  with CI helper usage and artifact guidance

## Validation
- ........................................................................ [ 54%]
.............................................................            [100%]
133 passed in 0.44s (pass)

## Notes
- Attempted to include workflow wiring, but current token scope cannot push  ( permission missing). This PR therefore delivers a safe, usable CI helper script + docs now; workflow hookup can be added once token scope is expanded.

Closes #111