### PR TITLE
[infra] Add end-user app entrypoint with Portfolio/Signals scaffold

### DIFF
--- a/enduser_app.py
+++ b/enduser_app.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+from src.enduser.app import run_enduser_app
+
+
+def main() -> None:
+    dsn = os.getenv("SUPABASE_DB_URL") or os.getenv("DATABASE_URL")
+    if not dsn:
+        raise ValueError("SUPABASE_DB_URL or DATABASE_URL is required")
+    run_enduser_app(dsn)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/enduser/app.py
+++ b/src/enduser/app.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import streamlit as st
+
+
+def run_enduser_app(dsn: str) -> None:
+    st.set_page_config(page_title="finance-flow-labs · End-user", layout="wide")
+    st.title("finance-flow-labs · End-user")
+    st.caption("Investor workspace (paper-trade intelligence).")
+
+    portfolio_tab, signals_tab = st.tabs(["Portfolio", "Signals"])
+
+    with portfolio_tab:
+        st.info("Coming soon")
+
+    with signals_tab:
+        st.info("Coming soon")

--- a/tests/test_enduser_app_smoke.py
+++ b/tests/test_enduser_app_smoke.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib
+import types
+
+import pytest
+
+
+class _TabContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_run_enduser_app_renders_portfolio_and_signals_tabs(monkeypatch):
+    calls: dict[str, object] = {"tabs": None, "info": []}
+
+    def set_page_config(**kwargs):
+        calls["page_config"] = kwargs
+
+    def title(text: str):
+        calls["title"] = text
+
+    def caption(text: str):
+        calls["caption"] = text
+
+    def tabs(labels: list[str]):
+        calls["tabs"] = labels
+        return [_TabContext(), _TabContext()]
+
+    def info(text: str):
+        calls["info"].append(text)
+
+    fake_streamlit = types.SimpleNamespace(
+        set_page_config=set_page_config,
+        title=title,
+        caption=caption,
+        tabs=tabs,
+        info=info,
+    )
+
+    monkeypatch.setitem(__import__("sys").modules, "streamlit", fake_streamlit)
+    app = importlib.import_module("src.enduser.app")
+
+    app.run_enduser_app("postgres://example")
+
+    assert calls["tabs"] == ["Portfolio", "Signals"]
+    assert calls["info"] == ["Coming soon", "Coming soon"]
+
+
+def test_enduser_entrypoint_requires_database_url(monkeypatch):
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    enduser_app = importlib.import_module("enduser_app")
+    with pytest.raises(ValueError, match="DATABASE_URL"):
+        enduser_app.main()


### PR DESCRIPTION
## Why
Issue #91 requests a dedicated end-user Streamlit entrypoint separated from the operator dashboard, with initial Portfolio/Signals tab navigation.

## What
- added `enduser_app.py` entrypoint
- added `src/enduser/app.py` with `run_enduser_app()`
- renders `st.tabs(["Portfolio", "Signals"])`
- each tab currently shows `st.info("Coming soon")` placeholder
- entrypoint reads `SUPABASE_DB_URL` or `DATABASE_URL` and fails fast when missing
- added smoke tests in `tests/test_enduser_app_smoke.py`

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- result: `139 passed`

Closes #91
