### PR TITLE
[signals] 매크로 레짐 신호 UI 카드 구현

### DIFF
--- a/src/enduser/app.py
+++ b/src/enduser/app.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import streamlit as st
 
+from src.enduser.signals import render_macro_regime_card
+
 
 def run_enduser_app(dsn: str) -> None:
     st.set_page_config(page_title="finance-flow-labs · End-user", layout="wide")
@@ -14,4 +16,5 @@ def run_enduser_app(dsn: str) -> None:
         st.info("Coming soon")
 
     with signals_tab:
-        st.info("Coming soon")
+        render_macro_regime_card(regime_signal=None)
+        st.info("More signal cards coming soon")

--- a/src/enduser/signals.py
+++ b/src/enduser/signals.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+import streamlit as st
+
+_REGIME_META: dict[str, tuple[str, str]] = {
+    "risk_on": ("🟢", "Risk-On"),
+    "risk_off": ("🔴", "Risk-Off"),
+    "neutral": ("⚪", "Neutral"),
+}
+
+
+def _normalize_as_of(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat(timespec="seconds")
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str) and value.strip():
+        return value
+    return "N/A"
+
+
+def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
+    st.subheader("Macro regime signal")
+
+    if not regime_signal:
+        st.info("No macro regime signal yet. Analysis pipeline data is pending.")
+        return
+
+    regime_key = str(regime_signal.get("regime", "neutral")).strip().lower().replace("-", "_")
+    emoji, regime_label = _REGIME_META.get(regime_key, _REGIME_META["neutral"])
+
+    confidence_raw = regime_signal.get("confidence", 0.0)
+    try:
+        confidence = max(0.0, min(float(confidence_raw), 1.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+
+    drivers = [str(item) for item in regime_signal.get("drivers", []) if str(item).strip()][:3]
+
+    st.markdown(f"### {emoji} {regime_label}")
+    st.caption(f"as_of: {_normalize_as_of(regime_signal.get('as_of'))}")
+
+    st.write(f"신뢰도: {confidence * 100:.0f}%")
+    st.progress(confidence)
+
+    st.write("핵심 드라이버 (Top 3):")
+    if drivers:
+        for driver in drivers:
+            st.write(f"• {driver}")
+    else:
+        st.write("• Driver data unavailable")

--- a/tests/test_enduser_app_smoke.py
+++ b/tests/test_enduser_app_smoke.py
@@ -15,7 +15,7 @@ class _TabContext:
 
 
 def test_run_enduser_app_renders_portfolio_and_signals_tabs(monkeypatch):
-    calls: dict[str, object] = {"tabs": None, "info": []}
+    calls: dict[str, object] = {"tabs": None, "info": [], "subheader": []}
 
     def set_page_config(**kwargs):
         calls["page_config"] = kwargs
@@ -23,15 +23,27 @@ def test_run_enduser_app_renders_portfolio_and_signals_tabs(monkeypatch):
     def title(text: str):
         calls["title"] = text
 
-    def caption(text: str):
-        calls["caption"] = text
-
     def tabs(labels: list[str]):
         calls["tabs"] = labels
         return [_TabContext(), _TabContext()]
 
+    def subheader(text: str):
+        calls["subheader"].append(text)
+
     def info(text: str):
         calls["info"].append(text)
+
+    def markdown(text: str):
+        calls.setdefault("markdown", []).append(text)
+
+    def caption(text: str):
+        calls.setdefault("captions", []).append(text)
+
+    def write(text: str):
+        calls.setdefault("write", []).append(text)
+
+    def progress(value: float):
+        calls.setdefault("progress", []).append(value)
 
     fake_streamlit = types.SimpleNamespace(
         set_page_config=set_page_config,
@@ -39,6 +51,10 @@ def test_run_enduser_app_renders_portfolio_and_signals_tabs(monkeypatch):
         caption=caption,
         tabs=tabs,
         info=info,
+        subheader=subheader,
+        markdown=markdown,
+        write=write,
+        progress=progress,
     )
 
     monkeypatch.setitem(__import__("sys").modules, "streamlit", fake_streamlit)
@@ -47,7 +63,12 @@ def test_run_enduser_app_renders_portfolio_and_signals_tabs(monkeypatch):
     app.run_enduser_app("postgres://example")
 
     assert calls["tabs"] == ["Portfolio", "Signals"]
-    assert calls["info"] == ["Coming soon", "Coming soon"]
+    assert calls["subheader"] == ["Macro regime signal"]
+    assert calls["info"] == [
+        "Coming soon",
+        "No macro regime signal yet. Analysis pipeline data is pending.",
+        "More signal cards coming soon",
+    ]
 
 
 def test_enduser_entrypoint_requires_database_url(monkeypatch):

--- a/tests/test_signals_ui.py
+++ b/tests/test_signals_ui.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def test_render_macro_regime_card_with_signal(monkeypatch):
+    calls: dict[str, list] = {
+        "subheader": [],
+        "markdown": [],
+        "caption": [],
+        "write": [],
+        "progress": [],
+        "info": [],
+    }
+
+    fake_streamlit = types.SimpleNamespace(
+        subheader=lambda text: calls["subheader"].append(text),
+        markdown=lambda text: calls["markdown"].append(text),
+        caption=lambda text: calls["caption"].append(text),
+        write=lambda text: calls["write"].append(text),
+        progress=lambda value: calls["progress"].append(value),
+        info=lambda text: calls["info"].append(text),
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+    sys.modules.pop("src.enduser.signals", None)
+    signals = importlib.import_module("src.enduser.signals")
+
+    signals.render_macro_regime_card(
+        {
+            "regime": "risk_on",
+            "confidence": 0.8,
+            "drivers": ["금리 하락 방향", "실업률 안정", "CPI 둔화", "ignored"],
+            "as_of": "2026-02-22T18:30:00Z",
+        }
+    )
+
+    assert calls["subheader"] == ["Macro regime signal"]
+    assert calls["markdown"] == ["### 🟢 Risk-On"]
+    assert calls["caption"] == ["as_of: 2026-02-22T18:30:00Z"]
+    assert calls["progress"] == [0.8]
+    assert "핵심 드라이버 (Top 3):" in calls["write"]
+    assert calls["write"].count("• 금리 하락 방향") == 1
+    assert calls["write"].count("• 실업률 안정") == 1
+    assert calls["write"].count("• CPI 둔화") == 1
+
+
+def test_render_macro_regime_card_placeholder_when_data_missing(monkeypatch):
+    calls: dict[str, list] = {"subheader": [], "info": []}
+
+    fake_streamlit = types.SimpleNamespace(
+        subheader=lambda text: calls["subheader"].append(text),
+        info=lambda text: calls["info"].append(text),
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+    sys.modules.pop("src.enduser.signals", None)
+    signals = importlib.import_module("src.enduser.signals")
+
+    signals.render_macro_regime_card(None)
+
+    assert calls["subheader"] == ["Macro regime signal"]
+    assert calls["info"] == ["No macro regime signal yet. Analysis pipeline data is pending."]


### PR DESCRIPTION
## Why
Signals 탭 최상단에서 현재 매크로 레짐을 빠르게 확인할 수 있는 카드가 필요합니다 (#100).

## What
- `src/enduser/signals.py`에 `render_macro_regime_card` 추가
  - 레짐별 색상/아이콘 렌더링 (Risk-On/Risk-Off/Neutral)
  - `st.progress()` 기반 신뢰도 표시
  - 핵심 드라이버 Top 3 렌더링
  - 데이터 미존재 시 placeholder 표시
- `src/enduser/app.py` Signals 탭에 매크로 레짐 카드 연결
- 스모크 테스트 업데이트 및 신규 단위 테스트 추가
  - `tests/test_enduser_app_smoke.py`
  - `tests/test_signals_ui.py`

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- 결과: `141 passed`

Closes #100
