### PR TITLE
Fix #122: wire end-user macro regime card to DB with freshness states

### DIFF
--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -58,6 +58,19 @@ Environment variables:
   - `read_latest_macro_analysis(limit)`
 - 저장 필드에는 `regime`, `confidence`, `base/bull/bear`, `policy_case`, `critic_case`, `reason_codes`, `risk_flags`, `triggers`, `narrative`, `model` 포함
 
+### End-user Signals wiring validation
+
+- End-user Signals 탭은 `src/enduser/macro_signal_reader.py`를 통해 `read_latest_macro_analysis(limit=1)`를 읽어 매크로 레짐 카드를 렌더링한다.
+- 상태 규칙:
+  - `ok`: 최신 신호 렌더링
+  - `stale`: 신호는 보이되 stale 경고 표시(기본 7일 초과)
+  - `missing`: DB 레코드 없음 경고
+  - `error`: malformed row/조회 실패 경고
+- 빠른 검증 절차:
+  1. `SUPABASE_DB_URL=... python3 -m src.ingestion.cli macro-analysis --as-of <ISO8601>`로 레코드 1건 저장
+  2. `streamlit run enduser_app.py` 실행
+  3. Signals 탭에서 regime/confidence/as_of/lineage 표시 및 stale/missing/error 상태 메시지 확인
+
 ## Forecast Capture (operator-safe)
 
 Use CLI (no direct SQL) to create/update a forecast record with schema validation and idempotency (`thesis_id + horizon + as_of`).

--- a/src/enduser/app.py
+++ b/src/enduser/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import streamlit as st
 
+from src.enduser.macro_signal_reader import read_latest_macro_regime_signal
 from src.enduser.signals import render_macro_regime_card
 
 
@@ -16,5 +17,6 @@ def run_enduser_app(dsn: str) -> None:
         st.info("Coming soon")
 
     with signals_tab:
-        render_macro_regime_card(regime_signal=None)
+        regime_signal = read_latest_macro_regime_signal(dsn)
+        render_macro_regime_card(regime_signal=regime_signal)
         st.info("More signal cards coming soon")

--- a/src/enduser/macro_signal_reader.py
+++ b/src/enduser/macro_signal_reader.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from src.ingestion.postgres_repository import PostgresRepository
+
+
+RepositoryFactory = Callable[[str], Any]
+
+
+def _parse_as_of(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value.strip():
+        raw = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(raw)
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def read_latest_macro_regime_signal(
+    dsn: str,
+    *,
+    freshness_days: int = 7,
+    repository_factory: RepositoryFactory = PostgresRepository,
+) -> dict[str, Any]:
+    try:
+        repository = repository_factory(dsn)
+        rows = repository.read_latest_macro_analysis(limit=1)
+    except Exception as exc:  # pragma: no cover - defensive UI boundary
+        return {
+            "status": "error",
+            "reason": "error",
+            "message": f"Failed to read macro regime signal: {exc}",
+        }
+
+    if not rows:
+        return {
+            "status": "missing",
+            "reason": "missing",
+            "message": "No macro regime record found in DB.",
+        }
+
+    row = rows[0]
+    regime = row.get("regime")
+    as_of = row.get("as_of")
+    confidence = row.get("confidence")
+
+    if not regime or as_of is None:
+        return {
+            "status": "error",
+            "reason": "malformed",
+            "message": "Latest macro regime row is malformed (missing regime/as_of).",
+            "raw": row,
+        }
+
+    as_of_dt = _parse_as_of(as_of)
+    stale = as_of_dt is None or as_of_dt < datetime.now(timezone.utc) - timedelta(days=freshness_days)
+
+    payload: dict[str, Any] = {
+        "status": "stale" if stale else "ok",
+        "reason": "stale" if stale else "ok",
+        "regime": regime,
+        "confidence": confidence,
+        "drivers": row.get("reason_codes") or [],
+        "as_of": as_of,
+        "lineage_id": row.get("run_id"),
+        "evidence_hard": row.get("evidence_hard") or [],
+        "evidence_soft": row.get("evidence_soft") or [],
+    }
+
+    if stale:
+        payload["message"] = f"Latest macro regime signal is stale (> {freshness_days} days)."
+
+    return payload

--- a/src/enduser/signals.py
+++ b/src/enduser/signals.py
@@ -29,6 +29,19 @@ def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
         st.info("No macro regime signal yet. Analysis pipeline data is pending.")
         return
 
+    status = str(regime_signal.get("status", "ok")).strip().lower()
+    if status in {"missing", "error"}:
+        message = str(regime_signal.get("message") or "Macro regime signal unavailable.")
+        st.warning(f"[{status}] {message}")
+        return
+
+    if status == "stale":
+        message = str(
+            regime_signal.get("message")
+            or "Signal is stale. Review ingestion pipeline before using this for decisions."
+        )
+        st.warning(f"[stale] {message}")
+
     regime_key = str(regime_signal.get("regime", "neutral")).strip().lower().replace("-", "_")
     emoji, regime_label = _REGIME_META.get(regime_key, _REGIME_META["neutral"])
 
@@ -42,6 +55,8 @@ def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
 
     st.markdown(f"### {emoji} {regime_label}")
     st.caption(f"as_of: {_normalize_as_of(regime_signal.get('as_of'))}")
+    if regime_signal.get("lineage_id"):
+        st.caption(f"lineage_id: {regime_signal.get('lineage_id')}")
 
     st.write(f"신뢰도: {confidence * 100:.0f}%")
     st.progress(confidence)

--- a/tests/test_enduser_macro_signal_service.py
+++ b/tests/test_enduser_macro_signal_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.enduser.macro_signal_reader import read_latest_macro_regime_signal
+
+
+class _Repo:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def read_latest_macro_analysis(self, limit=1):
+        return self._rows
+
+
+def test_read_latest_macro_regime_signal_happy_path():
+    as_of = datetime.now(timezone.utc).isoformat()
+    payload = read_latest_macro_regime_signal(
+        "postgres://example",
+        repository_factory=lambda _dsn: _Repo(
+            [
+                {
+                    "run_id": "run-1",
+                    "regime": "risk_on",
+                    "confidence": 0.82,
+                    "reason_codes": ["cpi_cooling"],
+                    "as_of": as_of,
+                    "evidence_hard": [{"source": "fred"}],
+                    "evidence_soft": [{"source": "news"}],
+                }
+            ]
+        ),
+    )
+
+    assert payload["status"] == "ok"
+    assert payload["regime"] == "risk_on"
+    assert payload["lineage_id"] == "run-1"
+
+
+def test_read_latest_macro_regime_signal_missing_row():
+    payload = read_latest_macro_regime_signal(
+        "postgres://example",
+        repository_factory=lambda _dsn: _Repo([]),
+    )
+
+    assert payload["status"] == "missing"
+    assert payload["reason"] == "missing"
+
+
+def test_read_latest_macro_regime_signal_stale_row():
+    stale_as_of = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    payload = read_latest_macro_regime_signal(
+        "postgres://example",
+        repository_factory=lambda _dsn: _Repo(
+            [{"run_id": "run-2", "regime": "neutral", "confidence": 0.5, "as_of": stale_as_of}]
+        ),
+    )
+
+    assert payload["status"] == "stale"
+    assert payload["reason"] == "stale"
+
+
+def test_read_latest_macro_regime_signal_malformed_row():
+    payload = read_latest_macro_regime_signal(
+        "postgres://example",
+        repository_factory=lambda _dsn: _Repo([{"run_id": "run-3", "confidence": 0.4}]),
+    )
+
+    assert payload["status"] == "error"
+    assert payload["reason"] == "malformed"


### PR DESCRIPTION
## Why\nSignals tab always rendered placeholder because macro regime card was hardcoded with , blocking end-user validation of persisted macro outputs.\n\n## What\n- added  to read latest macro analysis and map deterministic UI states ()\n- wired  to fetch DB-backed signal payload and pass it into \n- extended macro regime card to show stale/error/missing warnings and lineage id\n- added service tests () for happy path + empty + stale + malformed\n- updated smoke/UI tests to cover non-placeholder rendering and stale warning behavior\n- documented end-user signal validation flow in \n\n## Validation\n- ........................................................................ [ 49%]
........................................................................ [ 98%]
..                                                                       [100%]
146 passed in 0.47s\n- 146 passed\n