### PR TITLE
Fix #124: Streamlit explicit end-user/operator view routing

### DIFF
--- a/docs/STREAMLIT_VIEW_ROUTING.md
+++ b/docs/STREAMLIT_VIEW_ROUTING.md
@@ -1,0 +1,18 @@
+# Streamlit View Routing
+
+Primary deployment entrypoint is `streamlit_app.py` and now supports two explicit views:
+
+- `?view=enduser` (default): investor-facing workspace (`Portfolio`, `Signals`)
+- `?view=operator`: ingestion/policy operator dashboard
+
+## Behavior
+
+1. If `view` query param is provided and valid, it is used.
+2. If `view` is missing, the app restores the last view stored in Streamlit session state.
+3. If `view` is invalid, app falls back to `enduser` and shows a warning.
+4. In-app radio toggle keeps both surfaces one-click reachable.
+
+## Access status banner
+
+If `STREAMLIT_PUBLIC_URL` env is configured, both views render the same access health banner using `check_streamlit_access`.
+This keeps auth-wall/degraded signals visible regardless of active view.

--- a/docs/ingestion-runbook.md
+++ b/docs/ingestion-runbook.md
@@ -1,5 +1,7 @@
 # Ingestion Runbook
 
+> Streamlit routing note: see `docs/STREAMLIT_VIEW_ROUTING.md` for end-user/operator view semantics and query-param deep links.
+
 ## Core Flow
 
 1. Evaluate source with legal/reliability hard gates.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -406,13 +406,14 @@ def load_dashboard_view(dsn: str) -> dict[str, object]:
     return build_dashboard_view(repository)
 
 
-def run_streamlit_app(dsn: str) -> None:
+def run_streamlit_app(dsn: str, *, configure_page: bool = True) -> None:
     st = importlib.import_module("streamlit")
 
     view = load_dashboard_view(dsn)
     cards = build_operator_cards(view)
 
-    st.set_page_config(page_title="Ingestion Operator Dashboard", layout="wide")
+    if configure_page:
+        st.set_page_config(page_title="Ingestion Operator Dashboard", layout="wide")
     st.title("Ingestion Operator Dashboard")
     st.caption("Manual update monitoring (cron separated)")
 

--- a/src/enduser/app.py
+++ b/src/enduser/app.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-import streamlit as st
+import importlib
 
 from src.enduser.macro_signal_reader import read_latest_macro_regime_signal
 from src.enduser.signals import render_macro_regime_card
 
 
-def run_enduser_app(dsn: str) -> None:
-    st.set_page_config(page_title="finance-flow-labs · End-user", layout="wide")
+def run_enduser_app(dsn: str, *, configure_page: bool = True) -> None:
+    st = importlib.import_module("streamlit")
+
+    if configure_page:
+        st.set_page_config(page_title="finance-flow-labs · End-user", layout="wide")
     st.title("finance-flow-labs · End-user")
     st.caption("Investor workspace (paper-trade intelligence).")
 

--- a/src/enduser/signals.py
+++ b/src/enduser/signals.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from typing import Any
-
-import streamlit as st
+import importlib
 
 _REGIME_META: dict[str, tuple[str, str]] = {
     "risk_on": ("🟢", "Risk-On"),
@@ -23,6 +22,8 @@ def _normalize_as_of(value: object) -> str:
 
 
 def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
+    st = importlib.import_module("streamlit")
+
     st.subheader("Macro regime signal")
 
     if not regime_signal:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,4 +1,108 @@
-from src.dashboard.app import main
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+
+import streamlit as st
+
+from src.dashboard.app import run_streamlit_app
+from src.enduser.app import run_enduser_app
+from src.ingestion.streamlit_access import check_streamlit_access
+
+LOGGER = logging.getLogger(__name__)
+VALID_VIEWS = {"enduser", "operator"}
+DEFAULT_VIEW = "enduser"
+SESSION_KEY = "ffl_view"
+
+
+def _query_param_to_text(raw_value: object) -> str:
+    if isinstance(raw_value, list):
+        raw_value = raw_value[0] if raw_value else None
+    return str(raw_value or "").strip().lower()
+
+
+def _normalize_view(raw_value: object) -> str:
+    normalized = _query_param_to_text(raw_value)
+    if normalized in VALID_VIEWS:
+        return normalized
+    return DEFAULT_VIEW
+
+
+def resolve_view(
+    query_params: Mapping[str, object],
+    session_state: Mapping[str, object],
+) -> tuple[str, str | None]:
+    requested = query_params.get("view")
+    if requested is not None:
+        requested_text = _query_param_to_text(requested)
+        normalized = _normalize_view(requested)
+        if requested_text and requested_text not in VALID_VIEWS:
+            return normalized, f"Unknown view '{requested_text}'. Falling back to '{DEFAULT_VIEW}'."
+        return normalized, None
+
+    current = session_state.get(SESSION_KEY)
+    if current in VALID_VIEWS:
+        return str(current), None
+
+    return DEFAULT_VIEW, None
+
+
+def _render_access_status_banner() -> None:
+    base_url = os.getenv("STREAMLIT_PUBLIC_URL")
+    if not base_url:
+        return
+
+    result = check_streamlit_access(base_url).to_dict()
+    status = str(result.get("reason", "unknown"))
+
+    if bool(result.get("ok")):
+        st.success(f"Access status: OK ({status})")
+        return
+
+    checked_url = str(result.get("final_url") or base_url)
+    remediation = result.get("remediation_hint") or "Check deployment visibility and health."
+    st.error(f"Access status: DEGRADED ({status}) · url={checked_url}")
+    st.info(f"Remediation: {remediation}")
+
+
+def _render_view_toggle(active_view: str) -> str:
+    labels = ["End-user", "Operator"]
+    index = 0 if active_view == "enduser" else 1
+    selected = st.radio(
+        "Workspace",
+        labels,
+        index=index,
+        horizontal=True,
+        key="ffl_workspace_toggle",
+        help="Default landing is End-user. Operator is available for ingestion and policy diagnostics.",
+    )
+    return "enduser" if selected == "End-user" else "operator"
+
+
+def main() -> None:
+    dsn = os.getenv("SUPABASE_DB_URL") or os.getenv("DATABASE_URL")
+    if not dsn:
+        raise ValueError("SUPABASE_DB_URL or DATABASE_URL is required")
+
+    view, warning_message = resolve_view(st.query_params, st.session_state)
+
+    st.set_page_config(page_title="finance-flow-labs", layout="wide")
+
+    if warning_message:
+        LOGGER.warning(warning_message)
+        st.warning(warning_message)
+
+    selected_view = _render_view_toggle(view)
+    st.session_state[SESSION_KEY] = selected_view
+    st.query_params["view"] = selected_view
+
+    _render_access_status_banner()
+
+    if selected_view == "operator":
+        run_streamlit_app(dsn, configure_page=False)
+    else:
+        run_enduser_app(dsn, configure_page=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_streamlit_router.py
+++ b/tests/test_streamlit_router.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+
+
+router = importlib.import_module("streamlit_app")
+
+
+def test_resolve_view_defaults_to_enduser_when_no_query_or_session():
+    view, warning = router.resolve_view({}, {})
+
+    assert view == "enduser"
+    assert warning is None
+
+
+def test_resolve_view_uses_query_param_when_valid():
+    view, warning = router.resolve_view({"view": "operator"}, {})
+
+    assert view == "operator"
+    assert warning is None
+
+
+def test_resolve_view_falls_back_and_warns_when_invalid_query_param():
+    view, warning = router.resolve_view({"view": "admin"}, {})
+
+    assert view == "enduser"
+    assert warning is not None
+    assert "Unknown view 'admin'" in warning
+
+
+def test_resolve_view_uses_session_state_when_query_missing():
+    view, warning = router.resolve_view({}, {"ffl_view": "operator"})
+
+    assert view == "operator"
+    assert warning is None


### PR DESCRIPTION
## Why
- Primary deployment URL lacked explicit user-facing routing and defaulted to operator-oriented entrypoint.
- End-user Portfolio/Signals surface existed but was not reliably reachable from canonical URL.

## What
- Added canonical router in `streamlit_app.py` with explicit views:
  - `?view=enduser` (default)
  - `?view=operator`
- Added session-state persistence for selected view and in-app radio toggle.
- Added safe fallback + warning for invalid `view` params.
- Unified optional deployed-access banner for both surfaces (`STREAMLIT_PUBLIC_URL` configured).
- Refactored sub-app renderers to support router composition without duplicate page-config calls.
- Added route parser tests (`tests/test_streamlit_router.py`).
- Added docs (`docs/STREAMLIT_VIEW_ROUTING.md`) and runbook pointer.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: **151 passed**
