### PR TITLE
Add dual-view deploy smoke coverage for Streamlit routing

### DIFF
--- a/docs/STREAMLIT_VIEW_ROUTING.md
+++ b/docs/STREAMLIT_VIEW_ROUTING.md
@@ -16,3 +16,8 @@ Primary deployment entrypoint is `streamlit_app.py` and now supports two explici
 
 If `STREAMLIT_PUBLIC_URL` env is configured, both views render the same access health banner using `check_streamlit_access`.
 This keeps auth-wall/degraded signals visible regardless of active view.
+
+## Deploy/CI smoke coverage
+
+- `scripts/post_deploy_verify.sh` now checks three routes: default landing, `?view=enduser`, `?view=operator`.
+- `scripts/deploy_access_gate_ci.sh` enforces deploy-access gate on the same three routes and fails CI if any route regresses to auth-wall/degraded blocker state.

--- a/scripts/post_deploy_verify.sh
+++ b/scripts/post_deploy_verify.sh
@@ -3,7 +3,16 @@ set -euo pipefail
 
 URL="${1:-https://finance-flow-labs.streamlit.app/}"
 
-echo "[post-deploy-verify] streamlit access contract check: $URL"
-./scripts/streamlit_access_smoke_check.sh "$URL"
+check_route() {
+  local route_url="$1"
+  local label="$2"
+
+  echo "[post-deploy-verify] streamlit access contract check (${label}): ${route_url}"
+  ./scripts/streamlit_access_smoke_check.sh "$route_url"
+}
+
+check_route "$URL" "default"
+check_route "${URL}?view=enduser" "enduser"
+check_route "${URL}?view=operator" "operator"
 
 echo "[post-deploy-verify] ok"


### PR DESCRIPTION
## Why
Issue #124 requires deploy/CI smoke validation for both explicit Streamlit routes (`?view=enduser`, `?view=operator`) in addition to the default entrypoint, so routing regressions (including auth-wall drift) are caught before users do.

## What
- Updated `scripts/post_deploy_verify.sh` to check:
  - default URL
  - `?view=enduser`
  - `?view=operator`
- Reworked `scripts/deploy_access_gate_ci.sh` to run deploy-access gate across all three routes and fail if any route is a release blocker.
- Documented route-level smoke coverage in `docs/STREAMLIT_VIEW_ROUTING.md`.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (151 passed)

## Policy/evidence notes
- No schema change.
- No change to investment policy, execution mode, or benchmark definitions.
- HARD/SOFT evidence separation remains unchanged.
