### PR TITLE
[signals] Separate HARD/SOFT evidence in macro regime card

### DIFF
--- a/src/enduser/signals.py
+++ b/src/enduser/signals.py
@@ -68,3 +68,20 @@ def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
             st.write(f"• {driver}")
     else:
         st.write("• Driver data unavailable")
+
+    evidence_hard = [str(item) for item in regime_signal.get("evidence_hard", []) if str(item).strip()]
+    evidence_soft = [str(item) for item in regime_signal.get("evidence_soft", []) if str(item).strip()]
+
+    st.write("HARD evidence:")
+    if evidence_hard:
+        for item in evidence_hard[:3]:
+            st.write(f"• {item}")
+    else:
+        st.write("• 없음")
+
+    st.write("SOFT evidence:")
+    if evidence_soft:
+        for item in evidence_soft[:3]:
+            st.write(f"• {item}")
+    else:
+        st.write("• 없음")

--- a/tests/test_signals_ui.py
+++ b/tests/test_signals_ui.py
@@ -35,6 +35,8 @@ def test_render_macro_regime_card_with_signal(monkeypatch):
             "confidence": 0.8,
             "drivers": ["금리 하락 방향", "실업률 안정", "CPI 둔화", "ignored"],
             "as_of": "2026-02-22T18:30:00Z",
+            "evidence_hard": ["FRED:CPIAUCSL 3m down", "FRED:UNRATE stable"],
+            "evidence_soft": ["Fed commentary softer"],
         }
     )
 
@@ -46,6 +48,10 @@ def test_render_macro_regime_card_with_signal(monkeypatch):
     assert calls["write"].count("• 금리 하락 방향") == 1
     assert calls["write"].count("• 실업률 안정") == 1
     assert calls["write"].count("• CPI 둔화") == 1
+    assert "HARD evidence:" in calls["write"]
+    assert "SOFT evidence:" in calls["write"]
+    assert calls["write"].count("• FRED:CPIAUCSL 3m down") == 1
+    assert calls["write"].count("• Fed commentary softer") == 1
 
 
 def test_render_macro_regime_card_placeholder_when_data_missing(monkeypatch):


### PR DESCRIPTION
## Why
Issue #122 tracks end-user macro regime card readiness including freshness/evidence states. The card already had status + stale handling, but evidence fields were not surfaced to users.

## What
- Render explicit HARD evidence section in the macro regime signal card
- Render explicit SOFT evidence section separately
- Keep top-3 cap for each evidence list and graceful fallback (없음) when empty
- Extend UI test coverage to assert HARD/SOFT evidence rendering

## Validation
- FRED_API_KEY= ECOS_API_KEY= pytest -q
  - Result: 154 passed
