### PR TITLE
fix(signals): add deterministic fallback actions + freshness/source metadata

### DIFF
--- a/src/enduser/macro_signal_reader.py
+++ b/src/enduser/macro_signal_reader.py
@@ -61,6 +61,10 @@ def read_latest_macro_regime_signal(
     as_of_dt = _parse_as_of(as_of)
     stale = as_of_dt is None or as_of_dt < datetime.now(timezone.utc) - timedelta(days=freshness_days)
 
+    source_tags = row.get("source_tags") or []
+    if not source_tags:
+        source_tags = ["macro_analysis_results"]
+
     payload: dict[str, Any] = {
         "status": "stale" if stale else "ok",
         "reason": "stale" if stale else "ok",
@@ -69,6 +73,8 @@ def read_latest_macro_regime_signal(
         "drivers": row.get("reason_codes") or [],
         "as_of": as_of,
         "lineage_id": row.get("run_id"),
+        "source_tags": source_tags,
+        "freshness_days": freshness_days,
         "evidence_hard": row.get("evidence_hard") or [],
         "evidence_soft": row.get("evidence_soft") or [],
     }

--- a/tests/test_enduser_macro_signal_service.py
+++ b/tests/test_enduser_macro_signal_service.py
@@ -35,6 +35,8 @@ def test_read_latest_macro_regime_signal_happy_path():
     assert payload["status"] == "ok"
     assert payload["regime"] == "risk_on"
     assert payload["lineage_id"] == "run-1"
+    assert payload["source_tags"] == ["macro_analysis_results"]
+    assert payload["freshness_days"] == 7
 
 
 def test_read_latest_macro_regime_signal_missing_row():


### PR DESCRIPTION
## Why
Signals macro regime card needed explicit fallback actions and evidence/freshness metadata to keep HARD/SOFT decision flow auditable and deterministic for end-users.

## What
- enrich macro signal payload with `source_tags` and `freshness_days` in `macro_signal_reader`
- render `source_tags` + freshness policy captions in Signals macro regime card
- add deterministic `next_action` captions for missing/error/stale states
- extend UI/service tests for new metadata and fallback behavior

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- 154 passed
