### PR TITLE
fix: hide deploy access diagnostics from end-user view

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -48,6 +48,10 @@ def resolve_view(
     return DEFAULT_VIEW, None
 
 
+def _should_render_access_status_banner(active_view: str) -> bool:
+    return active_view == "operator"
+
+
 def _render_access_status_banner() -> None:
     base_url = os.getenv("STREAMLIT_PUBLIC_URL")
     if not base_url:
@@ -97,7 +101,8 @@ def main() -> None:
     st.session_state[SESSION_KEY] = selected_view
     st.query_params["view"] = selected_view
 
-    _render_access_status_banner()
+    if _should_render_access_status_banner(selected_view):
+        _render_access_status_banner()
 
     if selected_view == "operator":
         run_streamlit_app(dsn, configure_page=False)

--- a/tests/test_streamlit_entrypoint_smoke.py
+++ b/tests/test_streamlit_entrypoint_smoke.py
@@ -26,11 +26,12 @@ class FakeStreamlit:
 def test_main_defaults_to_enduser_view(monkeypatch):
     fake_st = FakeStreamlit(query_params={}, session_state={})
     calls: list[tuple[str, bool]] = []
+    banner_calls: list[str] = []
 
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
     monkeypatch.setattr(router, "st", fake_st)
     monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
-    monkeypatch.setattr(router, "_render_access_status_banner", lambda: None)
+    monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))
     monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
     monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))
 
@@ -38,16 +39,18 @@ def test_main_defaults_to_enduser_view(monkeypatch):
 
     assert calls == [("enduser", False)]
     assert fake_st.query_params["view"] == "enduser"
+    assert banner_calls == []
 
 
 def test_main_supports_operator_deep_link(monkeypatch):
     fake_st = FakeStreamlit(query_params={"view": "operator"}, session_state={})
     calls: list[tuple[str, bool]] = []
+    banner_calls: list[str] = []
 
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
     monkeypatch.setattr(router, "st", fake_st)
     monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
-    monkeypatch.setattr(router, "_render_access_status_banner", lambda: None)
+    monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))
     monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
     monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))
 
@@ -55,6 +58,7 @@ def test_main_supports_operator_deep_link(monkeypatch):
 
     assert calls == [("operator", False)]
     assert fake_st.query_params["view"] == "operator"
+    assert banner_calls == ["called"]
 
 
 def test_main_falls_back_to_enduser_on_unknown_view(monkeypatch):

--- a/tests/test_streamlit_router.py
+++ b/tests/test_streamlit_router.py
@@ -33,3 +33,8 @@ def test_resolve_view_uses_session_state_when_query_missing():
 
     assert view == "operator"
     assert warning is None
+
+
+def test_access_banner_visibility_is_operator_only():
+    assert router._should_render_access_status_banner("operator") is True
+    assert router._should_render_access_status_banner("enduser") is False


### PR DESCRIPTION
## Why
- End-user surface currently shows deployment-access diagnostics banner intended for operators.
- This leaks infra/auth-wall troubleshooting details into the user-facing dashboard.

## What
- Add  gate in .
- Render access-status banner only when active view is .
- Add/extend tests to verify:
  - banner visibility logic is operator-only
  -  does not render banner on end-user view
  -  still renders banner on operator deep-link

## Validation
- ........................................................................ [ 46%]
........................................................................ [ 92%]
...........                                                              [100%]
155 passed in 0.79s
  - 155 passed

## Issue
- Closes #131