### PR TITLE
fix(streamlit): prevent TypeError from view app signature skew

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
 import streamlit as st
 
@@ -84,6 +84,22 @@ def _render_view_toggle(active_view: str) -> str:
     return "enduser" if selected == "End-user" else "operator"
 
 
+def _run_view_app(app_fn: Callable[..., None], dsn: str) -> None:
+    """Invoke view app without duplicate page config, with legacy compatibility.
+
+    Some deployments can end up with version-skewed modules where app_fn does not
+    accept ``configure_page`` yet. Fall back to the legacy signature instead of
+    crashing the whole Streamlit shell.
+    """
+
+    try:
+        app_fn(dsn, configure_page=False)
+    except TypeError as exc:
+        if "configure_page" not in str(exc):
+            raise
+        app_fn(dsn)
+
+
 def main() -> None:
     dsn = os.getenv("SUPABASE_DB_URL") or os.getenv("DATABASE_URL")
     if not dsn:
@@ -105,9 +121,9 @@ def main() -> None:
         _render_access_status_banner()
 
     if selected_view == "operator":
-        run_streamlit_app(dsn, configure_page=False)
+        _run_view_app(run_streamlit_app, dsn)
     else:
-        run_enduser_app(dsn, configure_page=False)
+        _run_view_app(run_enduser_app, dsn)
 
 
 if __name__ == "__main__":

--- a/tests/test_streamlit_router.py
+++ b/tests/test_streamlit_router.py
@@ -38,3 +38,26 @@ def test_resolve_view_uses_session_state_when_query_missing():
 def test_access_banner_visibility_is_operator_only():
     assert router._should_render_access_status_banner("operator") is True
     assert router._should_render_access_status_banner("enduser") is False
+
+
+def test_run_view_app_passes_configure_page_when_supported():
+    called: dict[str, object] = {}
+
+    def supported(dsn: str, *, configure_page: bool = True) -> None:
+        called["dsn"] = dsn
+        called["configure_page"] = configure_page
+
+    router._run_view_app(supported, "postgres://dsn")
+
+    assert called == {"dsn": "postgres://dsn", "configure_page": False}
+
+
+def test_run_view_app_falls_back_when_configure_page_unsupported():
+    called: dict[str, object] = {}
+
+    def legacy(dsn: str) -> None:
+        called["dsn"] = dsn
+
+    router._run_view_app(legacy, "postgres://legacy")
+
+    assert called == {"dsn": "postgres://legacy"}


### PR DESCRIPTION
## Why
Streamlit production showed a `TypeError` at `run_streamlit_app(dsn, configure_page=False)` (version-skew style failure). When imported app functions do not accept `configure_page`, the whole shell crashes.

## What
- `streamlit_app.py`
  - Added `_run_view_app(app_fn, dsn)` compatibility wrapper.
  - Default path: call `app_fn(dsn, configure_page=False)`.
  - Fallback path: on `TypeError` mentioning `configure_page`, call legacy signature `app_fn(dsn)`.
  - Applied wrapper to both operator and end-user app invocations.
- `tests/test_streamlit_router.py`
  - Added test for configure_page-supported functions.
  - Added test for legacy signature fallback.

## Validation
- `pytest -q tests/test_streamlit_router.py tests/test_streamlit_access.py`
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
