### PR TITLE
fix: always display freshness policy even when 0-day threshold

### DIFF
--- a/src/enduser/signals.py
+++ b/src/enduser/signals.py
@@ -67,8 +67,9 @@ def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
     if regime_signal.get("source_tags"):
         tags = ", ".join(str(tag) for tag in regime_signal.get("source_tags", []) if str(tag).strip())
         st.caption(f"source_tags: {tags}")
-    if regime_signal.get("freshness_days"):
-        st.caption(f"freshness_policy: stale after {regime_signal.get('freshness_days')}d")
+    freshness_days = regime_signal.get("freshness_days")
+    if freshness_days is not None:
+        st.caption(f"freshness_policy: stale after {freshness_days}d")
 
     st.write(f"신뢰도: {confidence * 100:.0f}%")
     st.progress(confidence)

--- a/tests/test_signals_ui.py
+++ b/tests/test_signals_ui.py
@@ -82,6 +82,35 @@ def test_render_macro_regime_card_placeholder_when_data_missing(monkeypatch):
     assert calls["caption"] == ["next_action: run macro-analysis ingestion and refresh Signals tab"]
 
 
+def test_render_macro_regime_card_shows_freshness_policy_when_zero_days(monkeypatch):
+    calls: dict[str, list] = {"caption": []}
+
+    fake_streamlit = types.SimpleNamespace(
+        subheader=lambda *_: None,
+        markdown=lambda *_: None,
+        caption=lambda text: calls["caption"].append(text),
+        write=lambda *_: None,
+        progress=lambda *_: None,
+        info=lambda *_: None,
+        warning=lambda *_: None,
+    )
+
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+    sys.modules.pop("src.enduser.signals", None)
+    signals = importlib.import_module("src.enduser.signals")
+
+    signals.render_macro_regime_card(
+        {
+            "regime": "neutral",
+            "confidence": 0.5,
+            "as_of": "2026-02-22T00:00:00Z",
+            "freshness_days": 0,
+        }
+    )
+
+    assert "freshness_policy: stale after 0d" in calls["caption"]
+
+
 def test_render_macro_regime_card_shows_stale_state(monkeypatch):
     calls: dict[str, list] = {"subheader": [], "warning": [], "caption": []}
 


### PR DESCRIPTION
## Why
The end-user macro regime card hid  when  because the UI checked truthiness instead of explicit nullability. This can make critical same-day staleness policy invisible.

## What
- Updated  to display freshness policy whenever .
- Added UI test coverage for .

## Validation
- ....                                                                     [100%]
4 passed in 0.02s
- ........................................................................ [ 45%]
........................................................................ [ 90%]
...............                                                          [100%]
159 passed in 0.71s