### PR TITLE
Handle tuple-shaped Streamlit query param values in router

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -17,7 +17,7 @@ SESSION_KEY = "ffl_view"
 
 
 def _query_param_to_text(raw_value: object) -> str:
-    if isinstance(raw_value, list):
+    if isinstance(raw_value, (list, tuple)):
         raw_value = raw_value[0] if raw_value else None
     return str(raw_value or "").strip().lower()
 

--- a/tests/test_streamlit_router.py
+++ b/tests/test_streamlit_router.py
@@ -20,6 +20,13 @@ def test_resolve_view_uses_query_param_when_valid():
     assert warning is None
 
 
+def test_resolve_view_accepts_tuple_query_param_shape():
+    view, warning = router.resolve_view({"view": ("operator",)}, {})
+
+    assert view == "operator"
+    assert warning is None
+
+
 def test_resolve_view_falls_back_and_warns_when_invalid_query_param():
     view, warning = router.resolve_view({"view": "admin"}, {})
 


### PR DESCRIPTION
## Why
Some Streamlit runtime/query parser combinations can surface single query values as tuple-like sequences instead of lists. The router currently only normalizes list-shaped values, which can incorrectly downgrade valid `view=operator` requests when tuple values appear.

## What
- Extend `_query_param_to_text` to normalize both list and tuple sequence shapes.
- Add regression test for tuple-shaped query params in `resolve_view`.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (160 passed)
