### PR TITLE
fix: render Streamlit access-status banner on end-user view

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -49,7 +49,7 @@ def resolve_view(
 
 
 def _should_render_access_status_banner(active_view: str) -> bool:
-    return active_view == "operator"
+    return active_view in VALID_VIEWS
 
 
 def _render_access_status_banner() -> None:

--- a/tests/test_streamlit_entrypoint_smoke.py
+++ b/tests/test_streamlit_entrypoint_smoke.py
@@ -39,7 +39,7 @@ def test_main_defaults_to_enduser_view(monkeypatch):
 
     assert calls == [("enduser", False)]
     assert fake_st.query_params["view"] == "enduser"
-    assert banner_calls == []
+    assert banner_calls == ["called"]
 
 
 def test_main_supports_operator_deep_link(monkeypatch):

--- a/tests/test_streamlit_router.py
+++ b/tests/test_streamlit_router.py
@@ -42,9 +42,10 @@ def test_resolve_view_uses_session_state_when_query_missing():
     assert warning is None
 
 
-def test_access_banner_visibility_is_operator_only():
+def test_access_banner_visibility_is_enabled_for_both_views():
     assert router._should_render_access_status_banner("operator") is True
-    assert router._should_render_access_status_banner("enduser") is False
+    assert router._should_render_access_status_banner("enduser") is True
+    assert router._should_render_access_status_banner("unknown") is False
 
 
 def test_run_view_app_passes_configure_page_when_supported():


### PR DESCRIPTION
## Why
Issue #138 reports that the access-status banner is only rendered on the operator view, while docs specify visibility on both end-user and operator surfaces.

## What
- changed `_should_render_access_status_banner` to allow both valid views (`enduser`, `operator`)
- updated router unit test to assert banner rendering for both views
- updated entrypoint smoke test so default end-user route expects banner rendering path

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `160 passed`

Closes #138
