### PR TITLE
fix(channel): prevent YouTube transcript collection timeouts on blocked IP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psycopg2-binary>=2.9.9,<3
 feedparser>=6.0.11
 youtube-transcript-api>=0.6.2
 scrapetube>=2.1.2
+requests>=2.31.0

--- a/src/analysis/channel_client.py
+++ b/src/analysis/channel_client.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+import re
 
 import scrapetube
+from youtube_transcript_api import IpBlocked, RequestBlocked
 
 from src.analysis.transcript_client import TranscriptClient
 
@@ -12,6 +13,42 @@ from src.analysis.transcript_client import TranscriptClient
 DEFAULT_CHANNELS: dict[str, str] = {
     "박종훈의 지식한방": "@kpunch",
 }
+
+_DEFAULT_ATTEMPT_MULTIPLIER = 4
+_MIN_MAX_ATTEMPTS = 10
+_MAX_MAX_ATTEMPTS = 50
+
+_EN_DAYS_BY_UNIT = {
+    "minute": 1 / 1440,
+    "minutes": 1 / 1440,
+    "hour": 1 / 24,
+    "hours": 1 / 24,
+    "day": 1,
+    "days": 1,
+    "week": 7,
+    "weeks": 7,
+    "month": 30,
+    "months": 30,
+    "year": 365,
+    "years": 365,
+}
+
+_KO_DAYS_BY_UNIT = {
+    "분": 1 / 1440,
+    "시간": 1 / 24,
+    "일": 1,
+    "주": 7,
+    "개월": 30,
+    "년": 365,
+}
+
+_EN_RELATIVE_TIME_PATTERN = re.compile(
+    r"(?P<value>\d+)\s*(?P<unit>minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)\s+ago"
+)
+
+_KO_RELATIVE_TIME_PATTERN = re.compile(
+    r"(?P<value>\d+)\s*(?P<unit>분|시간|일|주|개월|년)\s*전"
+)
 
 
 class ChannelClient:
@@ -21,8 +58,8 @@ class ChannelClient:
     ``TranscriptClient`` to download captions.
     """
 
-    def __init__(self) -> None:
-        self._transcript_client = TranscriptClient()
+    def __init__(self, transcript_client: TranscriptClient | None = None) -> None:
+        self._transcript_client = transcript_client or TranscriptClient()
 
     def fetch(
         self,
@@ -30,6 +67,7 @@ class ChannelClient:
         days: int = 30,
         max_videos: int = 5,
         language: str = "ko",
+        max_attempts: int | None = None,
     ) -> list[dict[str, object]]:
         """Return transcripts for the most recent videos from *handle*.
 
@@ -38,25 +76,49 @@ class ChannelClient:
             days: Only include videos published within the last *days* days.
             max_videos: Maximum number of videos to retrieve.
             language: Preferred transcript language.
+            max_attempts: Maximum number of transcript attempts across videos.
+                          If omitted, uses a bounded default based on ``max_videos``.
 
         Returns:
             List of dicts with keys: video_id, title, published_at, transcript_text.
-            Entries for which transcript fetching fails are silently skipped.
+            Entries for which transcript fetching fails are skipped.
+
+        Notes:
+            - If YouTube blocks transcript access (IpBlocked/RequestBlocked),
+              fetching stops early to avoid long hangs.
+            - ``published_at`` filtering is best-effort because YouTube returns
+              relative text in mixed locales.
         """
-        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=days)
+        if days <= 0:
+            raise ValueError("days must be > 0")
+        if max_videos <= 0:
+            raise ValueError("max_videos must be > 0")
+
+        attempts_cap = max_attempts
+        if attempts_cap is None:
+            attempts_cap = _recommended_max_attempts(max_videos)
+        if attempts_cap <= 0:
+            raise ValueError("max_attempts must be > 0")
 
         results: list[dict[str, object]] = []
+        attempts = 0
+
         try:
             # channel_username with '@' handles fails on newer YouTube responses;
             # channel_url is the reliable alternative.
             if handle.startswith("@"):
                 videos = scrapetube.get_channel(
-                    channel_url=f"https://www.youtube.com/{handle}"
+                    channel_url=f"https://www.youtube.com/{handle}",
+                    limit=attempts_cap,
                 )
             else:
-                videos = scrapetube.get_channel(channel_username=handle)
+                videos = scrapetube.get_channel(
+                    channel_username=handle,
+                    limit=attempts_cap,
+                )
+
             for video in videos:
-                if len(results) >= max_videos:
+                if len(results) >= max_videos or attempts >= attempts_cap:
                     break
 
                 video_id: str = video.get("videoId", "")
@@ -64,7 +126,7 @@ class ChannelClient:
                     continue
 
                 # scrapetube returns publishedTimeText (relative) but not epoch;
-                # we attempt to parse the rich data when available.
+                # we attempt to parse the relative text when available.
                 title: str = ""
                 published_at: str = ""
                 try:
@@ -77,9 +139,15 @@ class ChannelClient:
                 except Exception:
                     pass
 
+                if not _is_within_days(published_at, days=days):
+                    continue
+
+                attempts += 1
                 try:
                     transcript_data = self._transcript_client.fetch(video_id, language=language)
                     transcript_text = transcript_data["transcript_text"]
+                except (IpBlocked, RequestBlocked):
+                    break
                 except Exception:
                     continue
 
@@ -95,3 +163,49 @@ class ChannelClient:
             pass
 
         return results
+
+
+def _recommended_max_attempts(max_videos: int) -> int:
+    """Return bounded default attempt count from desired output size."""
+    return max(
+        _MIN_MAX_ATTEMPTS,
+        min(_MAX_MAX_ATTEMPTS, max_videos * _DEFAULT_ATTEMPT_MULTIPLIER),
+    )
+
+
+def _is_within_days(published_at: str, days: int) -> bool:
+    """Return whether relative ``published_at`` appears within ``days``.
+
+    Unknown/unsupported formats are treated as in-range so we do not accidentally
+    drop valid data because of locale formatting quirks.
+    """
+    age_days = _parse_relative_age_days(published_at)
+    if age_days is None:
+        return True
+    return age_days <= days
+
+
+def _parse_relative_age_days(published_at: str) -> float | None:
+    """Best-effort parser for YouTube relative time text (EN/KO)."""
+    text = published_at.strip().lower()
+    if not text:
+        return None
+
+    if any(token in text for token in ("just now", "today", "방금 전", "오늘")):
+        return 0.0
+    if "yesterday" in text or "어제" in text:
+        return 1.0
+
+    english_match = _EN_RELATIVE_TIME_PATTERN.search(text)
+    if english_match:
+        value = int(english_match.group("value"))
+        unit = english_match.group("unit")
+        return value * _EN_DAYS_BY_UNIT[unit]
+
+    korean_match = _KO_RELATIVE_TIME_PATTERN.search(text)
+    if korean_match:
+        value = int(korean_match.group("value"))
+        unit = korean_match.group("unit")
+        return value * _KO_DAYS_BY_UNIT[unit]
+
+    return None

--- a/src/analysis/transcript_client.py
+++ b/src/analysis/transcript_client.py
@@ -3,8 +3,22 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
+import requests
 from youtube_transcript_api import YouTubeTranscriptApi
+
+
+class _TimeoutSession(requests.Session):
+    """requests.Session wrapper that enforces a default per-request timeout."""
+
+    def __init__(self, request_timeout_seconds: float) -> None:
+        super().__init__()
+        self._request_timeout_seconds = request_timeout_seconds
+
+    def request(self, method: str, url: str, **kwargs: Any):  # type: ignore[override]
+        kwargs.setdefault("timeout", self._request_timeout_seconds)
+        return super().request(method, url, **kwargs)
 
 
 def extract_video_id(url: str) -> str:
@@ -37,6 +51,14 @@ def extract_video_id(url: str) -> str:
 class TranscriptClient:
     """Fetches transcripts for individual YouTube videos."""
 
+    def __init__(self, request_timeout_seconds: float = 10.0) -> None:
+        if request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be > 0")
+
+        self._api = YouTubeTranscriptApi(
+            http_client=_TimeoutSession(request_timeout_seconds=request_timeout_seconds)
+        )
+
     def fetch(self, url: str, language: str = "ko") -> dict[str, object]:
         """Return the transcript for *url*.
 
@@ -55,12 +77,11 @@ class TranscriptClient:
         video_id = extract_video_id(url)
 
         fallback = "en" if language == "ko" else "ko"
-        api = YouTubeTranscriptApi()
         try:
-            fetched = api.fetch(video_id, languages=[language, fallback])
+            fetched = self._api.fetch(video_id, languages=[language, fallback])
             used_language = language
         except Exception:
-            fetched = api.fetch(video_id)
+            fetched = self._api.fetch(video_id)
             used_language = "auto"
 
         transcript_text = " ".join(entry.text for entry in fetched)

--- a/tests/test_analysis_channel_client.py
+++ b/tests/test_analysis_channel_client.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import src.analysis.channel_client as channel_client
+from youtube_transcript_api import IpBlocked
+
+
+def _video(video_id: str, published_at: str = "1 day ago") -> dict[str, object]:
+    return {
+        "videoId": video_id,
+        "title": {"runs": [{"text": f"title-{video_id}"}]},
+        "publishedTimeText": {"simpleText": published_at},
+    }
+
+
+def test_channel_fetch_respects_explicit_max_attempts(monkeypatch) -> None:
+    videos = [_video(f"v-{idx}") for idx in range(30)]
+    captured_limit: dict[str, int] = {}
+
+    def fake_get_channel(**kwargs):
+        captured_limit["value"] = int(kwargs["limit"])
+        return iter(videos)
+
+    monkeypatch.setattr(channel_client.scrapetube, "get_channel", fake_get_channel)
+
+    class AlwaysFailTranscriptClient:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def fetch(self, video_id: str, language: str = "ko") -> dict[str, object]:
+            self.calls.append(video_id)
+            raise RuntimeError("transcript fetch failed")
+
+    transcript_client = AlwaysFailTranscriptClient()
+    client = channel_client.ChannelClient(transcript_client=transcript_client)  # type: ignore[arg-type]
+
+    results = client.fetch("@kpunch", max_videos=3, max_attempts=5)
+
+    assert results == []
+    assert captured_limit["value"] == 5
+    assert len(transcript_client.calls) == 5
+
+
+def test_channel_fetch_stops_immediately_on_ip_blocked(monkeypatch) -> None:
+    videos = [_video("v-1"), _video("v-2"), _video("v-3")]
+
+    def fake_get_channel(**kwargs):
+        return iter(videos)
+
+    monkeypatch.setattr(channel_client.scrapetube, "get_channel", fake_get_channel)
+
+    class BlockedTranscriptClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def fetch(self, video_id: str, language: str = "ko") -> dict[str, object]:
+            self.calls += 1
+            raise IpBlocked(video_id)
+
+    transcript_client = BlockedTranscriptClient()
+    client = channel_client.ChannelClient(transcript_client=transcript_client)  # type: ignore[arg-type]
+
+    results = client.fetch("@kpunch", max_videos=3, max_attempts=10)
+
+    assert results == []
+    assert transcript_client.calls == 1
+
+
+def test_channel_fetch_applies_days_filter_for_parseable_relative_time(monkeypatch) -> None:
+    videos = [
+        _video("old-en", "40 days ago"),
+        _video("old-ko", "2개월 전"),
+        _video("new-en", "3 days ago"),
+        _video("new-ko", "12시간 전"),
+    ]
+
+    def fake_get_channel(**kwargs):
+        return iter(videos)
+
+    monkeypatch.setattr(channel_client.scrapetube, "get_channel", fake_get_channel)
+
+    class SuccessTranscriptClient:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def fetch(self, video_id: str, language: str = "ko") -> dict[str, object]:
+            self.calls.append(video_id)
+            return {"transcript_text": f"text-{video_id}"}
+
+    transcript_client = SuccessTranscriptClient()
+    client = channel_client.ChannelClient(transcript_client=transcript_client)  # type: ignore[arg-type]
+
+    results = client.fetch("@kpunch", days=30, max_videos=5, max_attempts=10)
+
+    assert [item["video_id"] for item in results] == ["new-en", "new-ko"]
+    assert transcript_client.calls == ["new-en", "new-ko"]
+
+
+def test_channel_fetch_uses_bounded_default_max_attempts(monkeypatch) -> None:
+    videos = [_video(f"v-{idx}") for idx in range(100)]
+    captured_limit: dict[str, int] = {}
+
+    def fake_get_channel(**kwargs):
+        captured_limit["value"] = int(kwargs["limit"])
+        return iter(videos)
+
+    monkeypatch.setattr(channel_client.scrapetube, "get_channel", fake_get_channel)
+
+    class AlwaysFailTranscriptClient:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def fetch(self, video_id: str, language: str = "ko") -> dict[str, object]:
+            self.calls.append(video_id)
+            raise RuntimeError("transcript fetch failed")
+
+    transcript_client = AlwaysFailTranscriptClient()
+    client = channel_client.ChannelClient(transcript_client=transcript_client)  # type: ignore[arg-type]
+
+    results = client.fetch("@kpunch", max_videos=2)
+
+    assert results == []
+    assert captured_limit["value"] == 10
+    assert len(transcript_client.calls) == 10

--- a/tests/test_analysis_transcript_client.py
+++ b/tests/test_analysis_transcript_client.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+import src.analysis.transcript_client as transcript_client
+
+
+class _Snippet:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def test_transcript_client_uses_timeout_session(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeApi:
+        def __init__(self, proxy_config=None, http_client=None) -> None:
+            captured["timeout"] = getattr(http_client, "_request_timeout_seconds", None)
+
+        def fetch(self, video_id: str, languages=("en",), preserve_formatting: bool = False):
+            captured.setdefault("calls", []).append(tuple(languages))  # type: ignore[attr-defined]
+            return [_Snippet("hello"), _Snippet("world")]
+
+    monkeypatch.setattr(transcript_client, "YouTubeTranscriptApi", FakeApi)
+
+    client = transcript_client.TranscriptClient(request_timeout_seconds=7.5)
+    payload = client.fetch("https://youtu.be/abcdefghijk", language="ko")
+
+    assert captured["timeout"] == 7.5
+    assert captured["calls"] == [("ko", "en")]
+    assert payload == {
+        "video_id": "abcdefghijk",
+        "language": "ko",
+        "transcript_text": "hello world",
+    }
+
+
+def test_transcript_client_falls_back_to_auto_language(monkeypatch) -> None:
+    captured: dict[str, object] = {"calls": 0}
+
+    class FakeApi:
+        def __init__(self, proxy_config=None, http_client=None) -> None:
+            pass
+
+        def fetch(self, video_id: str, languages=("en",), preserve_formatting: bool = False):
+            captured["calls"] = int(captured["calls"]) + 1
+            if captured["calls"] == 1:
+                raise RuntimeError("preferred language unavailable")
+            captured["fallback_languages"] = tuple(languages)
+            return [_Snippet("fallback")]
+
+    monkeypatch.setattr(transcript_client, "YouTubeTranscriptApi", FakeApi)
+
+    client = transcript_client.TranscriptClient(request_timeout_seconds=5)
+    payload = client.fetch("abcdefghijk", language="ko")
+
+    assert captured["calls"] == 2
+    assert captured["fallback_languages"] == ("en",)
+    assert payload == {
+        "video_id": "abcdefghijk",
+        "language": "auto",
+        "transcript_text": "fallback",
+    }
+
+
+def test_transcript_client_rejects_non_positive_timeout() -> None:
+    with pytest.raises(ValueError, match="request_timeout_seconds"):
+        transcript_client.TranscriptClient(request_timeout_seconds=0)


### PR DESCRIPTION
## Summary
- add per-request timeout support to `TranscriptClient` via a timeout-enabled HTTP session
- harden `ChannelClient` with bounded transcript attempts and fail-fast behavior on `IpBlocked` / `RequestBlocked`
- apply best-effort `days` filtering for parseable EN/KO relative publish time strings
- add regression tests for channel hang prevention and transcript timeout behavior

## Why
`python -m src.analysis.cli channel @kpunch ...` could run for a long time when transcript requests were blocked, because failures were skipped indefinitely while scanning videos.

## Validation
- `pytest -q` (167 passed)
- manual check: `python -m src.analysis.cli channel @kpunch --days 30 --max-videos 5` now returns quickly (empty list under IP block)
