### PR TITLE
feat: separate public end-user and operator surfaces (fix #141)

### DIFF
--- a/docs/STREAMLIT_VIEW_ROUTING.md
+++ b/docs/STREAMLIT_VIEW_ROUTING.md
@@ -1,16 +1,17 @@
 # Streamlit View Routing
 
-Primary deployment entrypoint is `streamlit_app.py` and now supports two explicit views:
+Primary deployment entrypoint is `streamlit_app.py` and supports two explicit views:
 
 - `?view=enduser` (default): investor-facing workspace (`Portfolio`, `Signals`)
-- `?view=operator`: ingestion/policy operator dashboard
+- `?view=operator`: ingestion/policy operator dashboard (**only when `ENABLE_OPERATOR_VIEW=true`**)
 
 ## Behavior
 
 1. If `view` query param is provided and valid, it is used.
-2. If `view` is missing, the app restores the last view stored in Streamlit session state.
-3. If `view` is invalid, app falls back to `enduser` and shows a warning.
-4. In-app radio toggle keeps both surfaces one-click reachable.
+2. If `view=operator` is requested while `ENABLE_OPERATOR_VIEW` is disabled, app falls back to `enduser` and shows an operator-only warning.
+3. If `view` is missing, the app restores the last view stored in Streamlit session state (operator session is also downgraded to enduser when operator mode is disabled).
+4. If `view` is invalid, app falls back to `enduser` and shows a warning.
+5. In-app workspace radio toggle is rendered only when `ENABLE_OPERATOR_VIEW=true`.
 
 ## Access status banner
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__)
 VALID_VIEWS = {"enduser", "operator"}
 DEFAULT_VIEW = "enduser"
 SESSION_KEY = "ffl_view"
+OPERATOR_VIEW_ENV = "ENABLE_OPERATOR_VIEW"
 
 
 def _query_param_to_text(raw_value: object) -> str:
@@ -29,9 +30,16 @@ def _normalize_view(raw_value: object) -> str:
     return DEFAULT_VIEW
 
 
+def _is_operator_view_enabled() -> bool:
+    raw = str(os.getenv(OPERATOR_VIEW_ENV, "")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def resolve_view(
     query_params: Mapping[str, object],
     session_state: Mapping[str, object],
+    *,
+    operator_enabled: bool,
 ) -> tuple[str, str | None]:
     requested = query_params.get("view")
     if requested is not None:
@@ -39,10 +47,14 @@ def resolve_view(
         normalized = _normalize_view(requested)
         if requested_text and requested_text not in VALID_VIEWS:
             return normalized, f"Unknown view '{requested_text}'. Falling back to '{DEFAULT_VIEW}'."
+        if normalized == "operator" and not operator_enabled:
+            return DEFAULT_VIEW, "Operator view is disabled. Set ENABLE_OPERATOR_VIEW=true to enable it."
         return normalized, None
 
     current = session_state.get(SESSION_KEY)
     if current in VALID_VIEWS:
+        if current == "operator" and not operator_enabled:
+            return DEFAULT_VIEW, "Operator view is disabled. Set ENABLE_OPERATOR_VIEW=true to enable it."
         return str(current), None
 
     return DEFAULT_VIEW, None
@@ -105,7 +117,12 @@ def main() -> None:
     if not dsn:
         raise ValueError("SUPABASE_DB_URL or DATABASE_URL is required")
 
-    view, warning_message = resolve_view(st.query_params, st.session_state)
+    operator_enabled = _is_operator_view_enabled()
+    view, warning_message = resolve_view(
+        st.query_params,
+        st.session_state,
+        operator_enabled=operator_enabled,
+    )
 
     st.set_page_config(page_title="finance-flow-labs", layout="wide")
 
@@ -113,7 +130,9 @@ def main() -> None:
         LOGGER.warning(warning_message)
         st.warning(warning_message)
 
-    selected_view = _render_view_toggle(view)
+    selected_view = view
+    if operator_enabled:
+        selected_view = _render_view_toggle(view)
     st.session_state[SESSION_KEY] = selected_view
     st.query_params["view"] = selected_view
 

--- a/tests/test_streamlit_entrypoint_smoke.py
+++ b/tests/test_streamlit_entrypoint_smoke.py
@@ -42,12 +42,35 @@ def test_main_defaults_to_enduser_view(monkeypatch):
     assert banner_calls == ["called"]
 
 
-def test_main_supports_operator_deep_link(monkeypatch):
+def test_main_operator_deep_link_falls_back_when_operator_disabled(monkeypatch):
     fake_st = FakeStreamlit(query_params={"view": "operator"}, session_state={})
     calls: list[tuple[str, bool]] = []
     banner_calls: list[str] = []
 
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
+    monkeypatch.delenv("ENABLE_OPERATOR_VIEW", raising=False)
+    monkeypatch.setattr(router, "st", fake_st)
+    monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
+    monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))
+    monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
+    monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))
+
+    router.main()
+
+    assert calls == [("enduser", False)]
+    assert fake_st.query_params["view"] == "enduser"
+    assert fake_st.warnings
+    assert "Operator view is disabled" in fake_st.warnings[0]
+    assert banner_calls == ["called"]
+
+
+def test_main_supports_operator_deep_link_when_enabled(monkeypatch):
+    fake_st = FakeStreamlit(query_params={"view": "operator"}, session_state={})
+    calls: list[tuple[str, bool]] = []
+    banner_calls: list[str] = []
+
+    monkeypatch.setenv("DATABASE_URL", "postgres://example")
+    monkeypatch.setenv("ENABLE_OPERATOR_VIEW", "true")
     monkeypatch.setattr(router, "st", fake_st)
     monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
     monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))

--- a/tests/test_streamlit_router.py
+++ b/tests/test_streamlit_router.py
@@ -7,28 +7,28 @@ router = importlib.import_module("streamlit_app")
 
 
 def test_resolve_view_defaults_to_enduser_when_no_query_or_session():
-    view, warning = router.resolve_view({}, {})
+    view, warning = router.resolve_view({}, {}, operator_enabled=False)
 
     assert view == "enduser"
     assert warning is None
 
 
-def test_resolve_view_uses_query_param_when_valid():
-    view, warning = router.resolve_view({"view": "operator"}, {})
+def test_resolve_view_uses_query_param_when_valid_and_operator_enabled():
+    view, warning = router.resolve_view({"view": "operator"}, {}, operator_enabled=True)
 
     assert view == "operator"
     assert warning is None
 
 
 def test_resolve_view_accepts_tuple_query_param_shape():
-    view, warning = router.resolve_view({"view": ("operator",)}, {})
+    view, warning = router.resolve_view({"view": ("operator",)}, {}, operator_enabled=True)
 
     assert view == "operator"
     assert warning is None
 
 
 def test_resolve_view_falls_back_and_warns_when_invalid_query_param():
-    view, warning = router.resolve_view({"view": "admin"}, {})
+    view, warning = router.resolve_view({"view": "admin"}, {}, operator_enabled=False)
 
     assert view == "enduser"
     assert warning is not None
@@ -36,10 +36,26 @@ def test_resolve_view_falls_back_and_warns_when_invalid_query_param():
 
 
 def test_resolve_view_uses_session_state_when_query_missing():
-    view, warning = router.resolve_view({}, {"ffl_view": "operator"})
+    view, warning = router.resolve_view({}, {"ffl_view": "operator"}, operator_enabled=True)
 
     assert view == "operator"
     assert warning is None
+
+
+def test_resolve_view_blocks_operator_query_when_operator_disabled():
+    view, warning = router.resolve_view({"view": "operator"}, {}, operator_enabled=False)
+
+    assert view == "enduser"
+    assert warning is not None
+    assert "Operator view is disabled" in warning
+
+
+def test_resolve_view_blocks_operator_session_when_operator_disabled():
+    view, warning = router.resolve_view({}, {"ffl_view": "operator"}, operator_enabled=False)
+
+    assert view == "enduser"
+    assert warning is not None
+    assert "Operator view is disabled" in warning
 
 
 def test_access_banner_visibility_is_enabled_for_both_views():


### PR DESCRIPTION
## Why
Public users currently see an End-user/Operator workspace toggle, which mixes personas and increases UX confusion.

## What
- Added explicit operator-mode gate via `ENABLE_OPERATOR_VIEW` env flag.
- Default/public behavior now routes to end-user surface only.
- Requests/sessions for `view=operator` fall back to `enduser` when operator mode is disabled, with warning.
- Kept operator dashboard reachable through explicit `?view=operator` when `ENABLE_OPERATOR_VIEW=true`.
- Updated routing docs and router/entrypoint tests for new contract.

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: `170 passed`
