### PR TITLE
fix: separate end-user default from operator surface

### DIFF
--- a/docs/ROUTING_ROLE_CONTRACT.md
+++ b/docs/ROUTING_ROLE_CONTRACT.md
@@ -1,0 +1,28 @@
+# Routing & Role Contract
+
+This document defines the intended audience split between the public investor experience and operator diagnostics.
+
+## Public default (End-user)
+- Entry: `/` (no query parameter required)
+- Renders: End-user investor workspace (`src/enduser/app.py`)
+- Audience: Investors consuming macro/sector/portfolio insights
+- UX rule: No role/workspace toggle exposed in the public default flow
+
+## Operator surface (explicit)
+- Entry: `/?view=operator`
+- Required flag: `ENABLE_OPERATOR_VIEW=true`
+- Renders: Operator diagnostics dashboard (`src/dashboard/app.py`)
+- Audience: Internal operator/maintainer workflows only
+
+If `view=operator` is requested while `ENABLE_OPERATOR_VIEW` is disabled, the app falls back to End-user view and shows a warning.
+
+## Environment knobs
+- `ENABLE_OPERATOR_VIEW` (default: disabled)
+  - truthy values: `1`, `true`, `yes`, `on`
+- `STREAMLIT_PUBLIC_URL`
+  - optional; when set, access status banner checks deployed accessibility
+
+## Design intent
+- Keep end-user surface simple and decision-focused.
+- Keep operator diagnostics available, but only through intentional routing and deployment-time control.
+- Reduce accidental exposure of operator-only complexity in public sessions.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -82,20 +82,6 @@ def _render_access_status_banner() -> None:
     st.info(f"Remediation: {remediation}")
 
 
-def _render_view_toggle(active_view: str) -> str:
-    labels = ["End-user", "Operator"]
-    index = 0 if active_view == "enduser" else 1
-    selected = st.radio(
-        "Workspace",
-        labels,
-        index=index,
-        horizontal=True,
-        key="ffl_workspace_toggle",
-        help="Default landing is End-user. Operator is available for ingestion and policy diagnostics.",
-    )
-    return "enduser" if selected == "End-user" else "operator"
-
-
 def _run_view_app(app_fn: Callable[..., None], dsn: str) -> None:
     """Invoke view app without duplicate page config, with legacy compatibility.
 
@@ -131,10 +117,11 @@ def main() -> None:
         st.warning(warning_message)
 
     selected_view = view
-    if operator_enabled:
-        selected_view = _render_view_toggle(view)
     st.session_state[SESSION_KEY] = selected_view
-    st.query_params["view"] = selected_view
+    if selected_view == "operator":
+        st.query_params["view"] = "operator"
+    elif "view" in st.query_params:
+        del st.query_params["view"]
 
     if _should_render_access_status_banner(selected_view):
         _render_access_status_banner()

--- a/tests/test_streamlit_entrypoint_smoke.py
+++ b/tests/test_streamlit_entrypoint_smoke.py
@@ -30,7 +30,6 @@ def test_main_defaults_to_enduser_view(monkeypatch):
 
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
     monkeypatch.setattr(router, "st", fake_st)
-    monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
     monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))
     monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
     monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))
@@ -38,7 +37,7 @@ def test_main_defaults_to_enduser_view(monkeypatch):
     router.main()
 
     assert calls == [("enduser", False)]
-    assert fake_st.query_params["view"] == "enduser"
+    assert "view" not in fake_st.query_params
     assert banner_calls == ["called"]
 
 
@@ -50,7 +49,6 @@ def test_main_operator_deep_link_falls_back_when_operator_disabled(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
     monkeypatch.delenv("ENABLE_OPERATOR_VIEW", raising=False)
     monkeypatch.setattr(router, "st", fake_st)
-    monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
     monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))
     monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
     monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))
@@ -58,7 +56,7 @@ def test_main_operator_deep_link_falls_back_when_operator_disabled(monkeypatch):
     router.main()
 
     assert calls == [("enduser", False)]
-    assert fake_st.query_params["view"] == "enduser"
+    assert "view" not in fake_st.query_params
     assert fake_st.warnings
     assert "Operator view is disabled" in fake_st.warnings[0]
     assert banner_calls == ["called"]
@@ -72,7 +70,6 @@ def test_main_supports_operator_deep_link_when_enabled(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
     monkeypatch.setenv("ENABLE_OPERATOR_VIEW", "true")
     monkeypatch.setattr(router, "st", fake_st)
-    monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
     monkeypatch.setattr(router, "_render_access_status_banner", lambda: banner_calls.append("called"))
     monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
     monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))
@@ -90,7 +87,6 @@ def test_main_falls_back_to_enduser_on_unknown_view(monkeypatch):
 
     monkeypatch.setenv("DATABASE_URL", "postgres://example")
     monkeypatch.setattr(router, "st", fake_st)
-    monkeypatch.setattr(router, "_render_view_toggle", lambda active_view: active_view)
     monkeypatch.setattr(router, "_render_access_status_banner", lambda: None)
     monkeypatch.setattr(router, "run_enduser_app", lambda dsn, configure_page=False: calls.append(("enduser", configure_page)))
     monkeypatch.setattr(router, "run_streamlit_app", lambda dsn, configure_page=False: calls.append(("operator", configure_page)))


### PR DESCRIPTION
## Why
Public default UX currently mixes end-user and operator personas via a workspace toggle. This creates avoidable confusion in investor-facing sessions.

## What
- Removed shell-level workspace toggle from `streamlit_app.py`
- Kept operator diagnostics reachable only via explicit `?view=operator` route
- Enforced deployment-time operator gating via `ENABLE_OPERATOR_VIEW`
- Cleaned query params so default end-user path stays at `/` without forced `view=enduser`
- Added routing/role contract doc at `docs/ROUTING_ROLE_CONTRACT.md`

## Validation
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`
- Result: 170 passed

Closes #141
