### PR TITLE
fix: aggregate streamlit route failures in post-deploy verify

### DIFF
--- a/scripts/post_deploy_verify.sh
+++ b/scripts/post_deploy_verify.sh
@@ -8,11 +8,23 @@ check_route() {
   local label="$2"
 
   echo "[post-deploy-verify] streamlit access contract check (${label}): ${route_url}"
-  ./scripts/streamlit_access_smoke_check.sh "$route_url"
+  if ./scripts/streamlit_access_smoke_check.sh "$route_url"; then
+    return 0
+  fi
+
+  echo "[post-deploy-verify] failed route: ${label}"
+  return 1
 }
 
-check_route "$URL" "default"
-check_route "${URL}?view=enduser" "enduser"
-check_route "${URL}?view=operator" "operator"
+failures=0
+
+check_route "$URL" "default" || failures=$((failures + 1))
+check_route "${URL}?view=enduser" "enduser" || failures=$((failures + 1))
+check_route "${URL}?view=operator" "operator" || failures=$((failures + 1))
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "[post-deploy-verify] failed (${failures} route(s))"
+  exit 1
+fi
 
 echo "[post-deploy-verify] ok"


### PR DESCRIPTION
## Why
Production gate is currently failing due to Streamlit auth-wall redirects. The existing post-deploy verifier exits on the first failing route, which hides full blast radius and slows incident triage.

## What
- Update [post-deploy-verify] streamlit access contract check (default): https://finance-flow-labs.streamlit.app/
{"url": "https://finance-flow-labs.streamlit.app/", "deploy_access_mode": "public", "restricted_login_path": null, "access_check": {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}, "gate": {"ok": false, "mode": "public", "release_blocker": true, "reason": "auth_wall_redirect_detected", "severity": "critical", "operator_message": "Public mode violation: unauthenticated dashboard access failed. Set Streamlit visibility to Public, redeploy, and rerun gate."}}
[post-deploy-verify] failed route: default
[post-deploy-verify] streamlit access contract check (enduser): https://finance-flow-labs.streamlit.app/?view=enduser
{"url": "https://finance-flow-labs.streamlit.app/?view=enduser", "deploy_access_mode": "public", "restricted_login_path": null, "access_check": {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/?view=enduser", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}, "gate": {"ok": false, "mode": "public", "release_blocker": true, "reason": "auth_wall_redirect_detected", "severity": "critical", "operator_message": "Public mode violation: unauthenticated dashboard access failed. Set Streamlit visibility to Public, redeploy, and rerun gate."}}
[post-deploy-verify] failed route: enduser
[post-deploy-verify] streamlit access contract check (operator): https://finance-flow-labs.streamlit.app/?view=operator
{"url": "https://finance-flow-labs.streamlit.app/?view=operator", "deploy_access_mode": "public", "restricted_login_path": null, "access_check": {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/?view=operator", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}, "gate": {"ok": false, "mode": "public", "release_blocker": true, "reason": "auth_wall_redirect_detected", "severity": "critical", "operator_message": "Public mode violation: unauthenticated dashboard access failed. Set Streamlit visibility to Public, redeploy, and rerun gate."}}
[post-deploy-verify] failed route: operator
[post-deploy-verify] failed (3 route(s)) to continue checking all required routes
- Count per-route failures and report aggregate failure summary
- Exit non-zero once all routes are evaluated if any route failed

## Validation
- ........................................................................ [ 41%]
..............F......................................................FFF [ 83%]
F...........................                                             [100%]
=================================== FAILURES ===================================
___________ test_run_enduser_app_renders_portfolio_and_signals_tabs ____________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72c88b93feb0>

    def test_run_enduser_app_renders_portfolio_and_signals_tabs(monkeypatch):
        calls: dict[str, object] = {"tabs": None, "info": [], "subheader": []}
    
        def set_page_config(**kwargs):
            calls["page_config"] = kwargs
    
        def title(text: str):
            calls["title"] = text
    
        def tabs(labels: list[str]):
            calls["tabs"] = labels
            return [_TabContext(), _TabContext()]
    
        def subheader(text: str):
            calls["subheader"].append(text)
    
        def info(text: str):
            calls["info"].append(text)
    
        def markdown(text: str):
            calls.setdefault("markdown", []).append(text)
    
        def caption(text: str):
            calls.setdefault("captions", []).append(text)
    
        def write(text: str):
            calls.setdefault("write", []).append(text)
    
        def progress(value: float):
            calls.setdefault("progress", []).append(value)
    
        fake_streamlit = types.SimpleNamespace(
            set_page_config=set_page_config,
            title=title,
            caption=caption,
            tabs=tabs,
            info=info,
            subheader=subheader,
            markdown=markdown,
            write=write,
            progress=progress,
            warning=lambda text: calls.setdefault("warning", []).append(text),
        )
    
        monkeypatch.setitem(__import__("sys").modules, "streamlit", fake_streamlit)
        app = importlib.import_module("src.enduser.app")
        monkeypatch.setattr(
            app,
            "read_latest_macro_regime_signal",
            lambda _dsn: {
                "status": "ok",
                "regime": "risk_on",
                "confidence": 0.7,
                "drivers": ["cpi_cooling"],
                "as_of": "2026-02-22T19:00:00Z",
                "lineage_id": "run-1",
            },
        )
    
>       app.run_enduser_app("postgres://example")

tests/test_enduser_app_smoke.py:76: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/enduser/app.py:24: in run_enduser_app
    render_macro_regime_card(regime_signal=regime_signal)
src/enduser/signals.py:101: in render_macro_regime_card
    _show_readiness_banner(st, readiness, message)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

st = namespace(set_page_config=<function test_run_enduser_app_renders_portfolio_and_signals_tabs.<locals>.set_page_config a...52560>, warning=<function test_run_enduser_app_renders_portfolio_and_signals_tabs.<locals>.<lambda> at 0x72c88b9525f0>)
readiness = 'READY'
message = 'Macro signal is available and within freshness policy.'

    def _show_readiness_banner(st: Any, readiness: str, message: str) -> None:
        emoji, channel = _READINESS_META[readiness]
        text = f"{emoji} **Signal readiness: {readiness}** — {message}"
        if channel == "success":
>           st.success(text)
E           AttributeError: 'types.SimpleNamespace' object has no attribute 'success'

src/enduser/signals.py:44: AttributeError
__________________ test_render_macro_regime_card_with_signal ___________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72c88b552500>

    def test_render_macro_regime_card_with_signal(monkeypatch):
        calls: dict[str, list] = {
            "subheader": [],
            "markdown": [],
            "caption": [],
            "write": [],
            "progress": [],
            "info": [],
        }
    
        fake_streamlit = types.SimpleNamespace(
            subheader=lambda text: calls["subheader"].append(text),
            markdown=lambda text: calls["markdown"].append(text),
            caption=lambda text: calls["caption"].append(text),
            write=lambda text: calls["write"].append(text),
            progress=lambda value: calls["progress"].append(value),
            info=lambda text: calls["info"].append(text),
            warning=lambda text: calls.setdefault("warning", []).append(text),
        )
    
        monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
        sys.modules.pop("src.enduser.signals", None)
        signals = importlib.import_module("src.enduser.signals")
    
>       signals.render_macro_regime_card(
            {
                "regime": "risk_on",
                "confidence": 0.8,
                "drivers": ["금리 하락 방향", "실업률 안정", "CPI 둔화", "ignored"],
                "as_of": "2026-02-22T18:30:00Z",
                "source_tags": ["macro_analysis_results"],
                "freshness_days": 7,
                "evidence_hard": ["FRED:CPIAUCSL 3m down", "FRED:UNRATE stable"],
                "evidence_soft": ["Fed commentary softer"],
            }
        )

tests/test_signals_ui.py:32: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/enduser/signals.py:101: in render_macro_regime_card
    _show_readiness_banner(st, readiness, message)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

st = namespace(subheader=<function test_render_macro_regime_card_with_signal.<locals>.<lambda> at 0x72c88b90f9a0>, markdown...> at 0x72c88b950790>, warning=<function test_render_macro_regime_card_with_signal.<locals>.<lambda> at 0x72c88b950820>)
readiness = 'READY'
message = 'Macro signal is available and within freshness policy.'

    def _show_readiness_banner(st: Any, readiness: str, message: str) -> None:
        emoji, channel = _READINESS_META[readiness]
        text = f"{emoji} **Signal readiness: {readiness}** — {message}"
        if channel == "success":
>           st.success(text)
E           AttributeError: 'types.SimpleNamespace' object has no attribute 'success'

src/enduser/signals.py:44: AttributeError
_________ test_render_macro_regime_card_placeholder_when_data_missing __________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72c88b512950>

    def test_render_macro_regime_card_placeholder_when_data_missing(monkeypatch):
        calls: dict[str, list] = {"subheader": [], "info": [], "warning": [], "caption": []}
    
        fake_streamlit = types.SimpleNamespace(
            subheader=lambda text: calls["subheader"].append(text),
            info=lambda text: calls["info"].append(text),
            warning=lambda text: calls["warning"].append(text),
            caption=lambda text: calls["caption"].append(text),
        )
    
        monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
        sys.modules.pop("src.enduser.signals", None)
        signals = importlib.import_module("src.enduser.signals")
    
>       signals.render_macro_regime_card(None)

tests/test_signals_ui.py:77: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/enduser/signals.py:102: in render_macro_regime_card
    _render_decision_guidance(st, readiness)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

st = namespace(subheader=<function test_render_macro_regime_card_placeholder_when_data_missing.<locals>.<lambda> at 0x72c88...0>, caption=<function test_render_macro_regime_card_placeholder_when_data_missing.<locals>.<lambda> at 0x72c88b502a70>)
readiness = 'MISSING'

    def _render_decision_guidance(st: Any, readiness: str) -> None:
>       st.write("Decision guidance:")
E       AttributeError: 'types.SimpleNamespace' object has no attribute 'write'

src/enduser/signals.py:52: AttributeError
_____ test_render_macro_regime_card_shows_freshness_policy_when_zero_days ______

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72c88b551bd0>

    def test_render_macro_regime_card_shows_freshness_policy_when_zero_days(monkeypatch):
        calls: dict[str, list] = {"caption": []}
    
        fake_streamlit = types.SimpleNamespace(
            subheader=lambda *_: None,
            markdown=lambda *_: None,
            caption=lambda text: calls["caption"].append(text),
            write=lambda *_: None,
            progress=lambda *_: None,
            info=lambda *_: None,
            warning=lambda *_: None,
        )
    
        monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
        sys.modules.pop("src.enduser.signals", None)
        signals = importlib.import_module("src.enduser.signals")
    
>       signals.render_macro_regime_card(
            {
                "regime": "neutral",
                "confidence": 0.5,
                "as_of": "2026-02-22T00:00:00Z",
                "freshness_days": 0,
            }
        )

tests/test_signals_ui.py:102: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/enduser/signals.py:101: in render_macro_regime_card
    _show_readiness_banner(st, readiness, message)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

st = namespace(subheader=<function test_render_macro_regime_card_shows_freshness_policy_when_zero_days.<locals>.<lambda> at...ing=<function test_render_macro_regime_card_shows_freshness_policy_when_zero_days.<locals>.<lambda> at 0x72c88b503490>)
readiness = 'READY'
message = 'Macro signal is available and within freshness policy.'

    def _show_readiness_banner(st: Any, readiness: str, message: str) -> None:
        emoji, channel = _READINESS_META[readiness]
        text = f"{emoji} **Signal readiness: {readiness}** — {message}"
        if channel == "success":
>           st.success(text)
E           AttributeError: 'types.SimpleNamespace' object has no attribute 'success'

src/enduser/signals.py:44: AttributeError
_______________ test_render_macro_regime_card_shows_stale_state ________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72c88b93f070>

    def test_render_macro_regime_card_shows_stale_state(monkeypatch):
        calls: dict[str, list] = {"subheader": [], "warning": [], "caption": []}
    
        fake_streamlit = types.SimpleNamespace(
            subheader=lambda text: calls["subheader"].append(text),
            warning=lambda text: calls["warning"].append(text),
            markdown=lambda *_: None,
            caption=lambda text: calls["caption"].append(text),
            write=lambda *_: None,
            progress=lambda *_: None,
        )
    
        monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
        sys.modules.pop("src.enduser.signals", None)
        signals = importlib.import_module("src.enduser.signals")
    
        signals.render_macro_regime_card(
            {"status": "stale", "message": "Latest macro regime signal is stale (> 7 days).", "regime": "neutral", "confidence": 0.4, "as_of": "2026-02-01T00:00:00Z"}
        )
    
        assert calls["subheader"] == ["Macro regime signal"]
>       assert calls["warning"] == ["[stale] Latest macro regime signal is stale (> 7 days)."]
E       AssertionError: assert ['⚠️ **Signal... (> 7 days).'] == ['[stale] Lat... (> 7 days).']
E         
E         At index 0 diff: '⚠️ **Signal readiness: STALE** — Latest macro regime signal is stale (> 7 days).' != '[stale] Latest macro regime signal is stale (> 7 days).'
E         Use -v to get more diff

tests/test_signals_ui.py:135: AssertionError
=========================== short test summary info ============================
FAILED tests/test_enduser_app_smoke.py::test_run_enduser_app_renders_portfolio_and_signals_tabs
FAILED tests/test_signals_ui.py::test_render_macro_regime_card_with_signal - ...
FAILED tests/test_signals_ui.py::test_render_macro_regime_card_placeholder_when_data_missing
FAILED tests/test_signals_ui.py::test_render_macro_regime_card_shows_freshness_policy_when_zero_days
FAILED tests/test_signals_ui.py::test_render_macro_regime_card_shows_stale_state
5 failed, 167 passed in 0.88s (172 passed)
- [post-deploy-verify] streamlit access contract check (default): https://finance-flow-labs.streamlit.app/
{"url": "https://finance-flow-labs.streamlit.app/", "deploy_access_mode": "public", "restricted_login_path": null, "access_check": {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}, "gate": {"ok": false, "mode": "public", "release_blocker": true, "reason": "auth_wall_redirect_detected", "severity": "critical", "operator_message": "Public mode violation: unauthenticated dashboard access failed. Set Streamlit visibility to Public, redeploy, and rerun gate."}}
[post-deploy-verify] failed route: default
[post-deploy-verify] streamlit access contract check (enduser): https://finance-flow-labs.streamlit.app/?view=enduser
{"url": "https://finance-flow-labs.streamlit.app/?view=enduser", "deploy_access_mode": "public", "restricted_login_path": null, "access_check": {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/?view=enduser", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}, "gate": {"ok": false, "mode": "public", "release_blocker": true, "reason": "auth_wall_redirect_detected", "severity": "critical", "operator_message": "Public mode violation: unauthenticated dashboard access failed. Set Streamlit visibility to Public, redeploy, and rerun gate."}}
[post-deploy-verify] failed route: enduser
[post-deploy-verify] streamlit access contract check (operator): https://finance-flow-labs.streamlit.app/?view=operator
{"url": "https://finance-flow-labs.streamlit.app/?view=operator", "deploy_access_mode": "public", "restricted_login_path": null, "access_check": {"ok": false, "status_code": 200, "final_url": "https://finance-flow-labs.streamlit.app/?view=operator", "auth_wall_redirect": true, "reason": "auth_wall_redirect_detected", "alert": true, "alert_severity": "critical", "remediation_hint": "auth_wall_detected: verify Streamlit Community Cloud visibility is set to Public (or document restricted-mode operator login path), then redeploy and rerun streamlit-access-check"}, "gate": {"ok": false, "mode": "public", "release_blocker": true, "reason": "auth_wall_redirect_detected", "severity": "critical", "operator_message": "Public mode violation: unauthenticated dashboard access failed. Set Streamlit visibility to Public, redeploy, and rerun gate."}}
[post-deploy-verify] failed route: operator
[post-deploy-verify] failed (3 route(s)) now reports default/enduser/operator route failures in one run and exits 1
