### PR TITLE
[signals] Add actionable readiness UX for stale/missing/error macro regime

### DIFF
--- a/src/enduser/signals.py
+++ b/src/enduser/signals.py
@@ -10,6 +10,13 @@ _REGIME_META: dict[str, tuple[str, str]] = {
     "neutral": ("⚪", "Neutral"),
 }
 
+_READINESS_META: dict[str, tuple[str, str]] = {
+    "ready": ("✅", "READY"),
+    "stale": ("⚠️", "STALE"),
+    "missing": ("🟨", "MISSING"),
+    "error": ("🛑", "ERROR"),
+}
+
 
 def _normalize_as_of(value: object) -> str:
     if isinstance(value, datetime):
@@ -21,79 +28,128 @@ def _normalize_as_of(value: object) -> str:
     return "N/A"
 
 
+def _normalize_readiness(status: object) -> str:
+    normalized = str(status or "ok").strip().lower()
+    if normalized in {"ok", "ready"}:
+        return "ready"
+    if normalized in {"stale", "missing", "error"}:
+        return normalized
+    return "error"
+
+
+def _emit(st: Any, level: str, text: str) -> None:
+    fn = getattr(st, level, None)
+    if callable(fn):
+        fn(text)
+        return
+    fallback = getattr(st, "write", None)
+    if callable(fallback):
+        fallback(text)
+
+
+def _render_decision_guidance(st: Any, readiness: str) -> None:
+    if readiness == "ready":
+        _emit(st, "success", "Decision guidance: Macro signal is decision-grade for thesis review (still apply portfolio risk limits).")
+        st.write("Data update path: scheduled macro ingestion pipeline.")
+        return
+
+    if readiness == "stale":
+        _emit(st, "warning", "Decision guidance: Do not execute new thesis entries from this signal until fresh data is available.")
+        st.write("Data update path: wait for next scheduled ingestion or ask operator to trigger manual refresh.")
+        return
+
+    if readiness == "missing":
+        _emit(st, "warning", "Decision guidance: Block signal-based investment action. No macro regime record is available yet.")
+        st.write("Data update path: ingestion must create at least one macro regime snapshot.")
+        return
+
+    _emit(st, "error", "Decision guidance: Block signal-based investment action until data integrity issue is resolved.")
+    st.write("Data update path: operator should inspect ingestion/DB integrity and rerun pipeline.")
+
+
+def _render_freshness_lineage(st: Any, regime_signal: dict[str, Any]) -> None:
+    st.write("Data freshness & lineage")
+    st.caption(f"as_of: {_normalize_as_of(regime_signal.get('as_of'))}")
+
+    freshness_days = regime_signal.get("freshness_days")
+    if freshness_days is not None:
+        st.caption(f"freshness_threshold: {freshness_days}d")
+
+    lineage_id = regime_signal.get("lineage_id")
+    if lineage_id:
+        st.caption(f"lineage_id: {lineage_id}")
+
+    source_tags = regime_signal.get("source_tags")
+    if source_tags:
+        tags = ", ".join(str(tag) for tag in source_tags if str(tag).strip())
+        if tags:
+            st.caption(f"source_tags: {tags}")
+
+
 def render_macro_regime_card(regime_signal: dict[str, Any] | None) -> None:
     st = importlib.import_module("streamlit")
 
     st.subheader("Macro regime signal")
 
-    if not regime_signal:
-        st.info("No macro regime signal yet. Analysis pipeline data is pending.")
-        st.caption("next_action: run macro-analysis ingestion and refresh Signals tab")
-        return
+    payload = regime_signal or {"status": "missing", "message": "No macro regime signal yet. Analysis pipeline data is pending."}
+    readiness = _normalize_readiness(payload.get("status"))
+    badge_emoji, badge_label = _READINESS_META[readiness]
+    st.markdown(f"### {badge_emoji} {badge_label}")
 
-    status = str(regime_signal.get("status", "ok")).strip().lower()
-    if status in {"missing", "error"}:
-        message = str(regime_signal.get("message") or "Macro regime signal unavailable.")
-        st.warning(f"[{status}] {message}")
-        if status == "missing":
-            st.caption("next_action: seed at least one macro regime row, then reload")
+    message = str(payload.get("message") or "").strip()
+    if message:
+        if readiness == "error":
+            st.error(message)
+        elif readiness in {"stale", "missing"}:
+            st.warning(message)
         else:
-            st.caption("next_action: inspect malformed row/DB connectivity and rerun")
-        return
+            st.info(message)
 
-    if status == "stale":
-        message = str(
-            regime_signal.get("message")
-            or "Signal is stale. Review ingestion pipeline before using this for decisions."
-        )
-        st.warning(f"[stale] {message}")
-        st.caption("next_action: rerun macro-analysis pipeline to refresh as_of")
+    _render_decision_guidance(st, readiness)
 
-    regime_key = str(regime_signal.get("regime", "neutral")).strip().lower().replace("-", "_")
-    emoji, regime_label = _REGIME_META.get(regime_key, _REGIME_META["neutral"])
+    if readiness in {"ready", "stale"}:
+        regime_key = str(payload.get("regime", "neutral")).strip().lower().replace("-", "_")
+        emoji, regime_label = _REGIME_META.get(regime_key, _REGIME_META["neutral"])
 
-    confidence_raw = regime_signal.get("confidence", 0.0)
-    try:
-        confidence = max(0.0, min(float(confidence_raw), 1.0))
-    except (TypeError, ValueError):
-        confidence = 0.0
+        confidence_raw = payload.get("confidence", 0.0)
+        try:
+            confidence = max(0.0, min(float(confidence_raw), 1.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
 
-    drivers = [str(item) for item in regime_signal.get("drivers", []) if str(item).strip()][:3]
+        drivers = [str(item) for item in payload.get("drivers", []) if str(item).strip()][:3]
 
-    st.markdown(f"### {emoji} {regime_label}")
-    st.caption(f"as_of: {_normalize_as_of(regime_signal.get('as_of'))}")
-    if regime_signal.get("lineage_id"):
-        st.caption(f"lineage_id: {regime_signal.get('lineage_id')}")
-    if regime_signal.get("source_tags"):
-        tags = ", ".join(str(tag) for tag in regime_signal.get("source_tags", []) if str(tag).strip())
-        st.caption(f"source_tags: {tags}")
-    freshness_days = regime_signal.get("freshness_days")
-    if freshness_days is not None:
-        st.caption(f"freshness_policy: stale after {freshness_days}d")
+        st.markdown(f"#### Regime: {emoji} {regime_label}")
+        st.write(f"신뢰도: {confidence * 100:.0f}%")
+        st.progress(confidence)
 
-    st.write(f"신뢰도: {confidence * 100:.0f}%")
-    st.progress(confidence)
+        st.write("핵심 드라이버 (Top 3):")
+        if drivers:
+            for driver in drivers:
+                st.write(f"• {driver}")
+        else:
+            st.write("• Driver data unavailable")
 
-    st.write("핵심 드라이버 (Top 3):")
-    if drivers:
-        for driver in drivers:
-            st.write(f"• {driver}")
-    else:
-        st.write("• Driver data unavailable")
+        evidence_hard = [str(item) for item in payload.get("evidence_hard", []) if str(item).strip()]
+        evidence_soft = [str(item) for item in payload.get("evidence_soft", []) if str(item).strip()]
 
-    evidence_hard = [str(item) for item in regime_signal.get("evidence_hard", []) if str(item).strip()]
-    evidence_soft = [str(item) for item in regime_signal.get("evidence_soft", []) if str(item).strip()]
+        st.write("HARD evidence:")
+        if evidence_hard:
+            for item in evidence_hard[:3]:
+                st.write(f"• {item}")
+        else:
+            st.write("• 없음")
 
-    st.write("HARD evidence:")
-    if evidence_hard:
-        for item in evidence_hard[:3]:
-            st.write(f"• {item}")
-    else:
-        st.write("• 없음")
+        st.write("SOFT evidence:")
+        if evidence_soft:
+            for item in evidence_soft[:3]:
+                st.write(f"• {item}")
+        else:
+            st.write("• 없음")
 
-    st.write("SOFT evidence:")
-    if evidence_soft:
-        for item in evidence_soft[:3]:
-            st.write(f"• {item}")
-    else:
-        st.write("• 없음")
+    _render_freshness_lineage(st, payload)
+
+    if hasattr(st, "button"):
+        requested = st.button("Request data refresh", key="macro_refresh_request")
+        if requested:
+            st.info("Refresh request recorded. Operator can run a manual macro ingestion trigger.")

--- a/tests/test_signals_ui.py
+++ b/tests/test_signals_ui.py
@@ -5,7 +5,7 @@ import sys
 import types
 
 
-def test_render_macro_regime_card_with_signal(monkeypatch):
+def _load_signals_with_fake_streamlit(monkeypatch, *, button_return: bool = False):
     calls: dict[str, list] = {
         "subheader": [],
         "markdown": [],
@@ -13,7 +13,15 @@ def test_render_macro_regime_card_with_signal(monkeypatch):
         "write": [],
         "progress": [],
         "info": [],
+        "warning": [],
+        "error": [],
+        "success": [],
+        "button": [],
     }
+
+    def _button(label, key=None):
+        calls["button"].append((label, key))
+        return button_return
 
     fake_streamlit = types.SimpleNamespace(
         subheader=lambda text: calls["subheader"].append(text),
@@ -22,115 +30,90 @@ def test_render_macro_regime_card_with_signal(monkeypatch):
         write=lambda text: calls["write"].append(text),
         progress=lambda value: calls["progress"].append(value),
         info=lambda text: calls["info"].append(text),
-        warning=lambda text: calls.setdefault("warning", []).append(text),
+        warning=lambda text: calls["warning"].append(text),
+        error=lambda text: calls["error"].append(text),
+        success=lambda text: calls["success"].append(text),
+        button=_button,
     )
 
     monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
     sys.modules.pop("src.enduser.signals", None)
     signals = importlib.import_module("src.enduser.signals")
+    return signals, calls
+
+
+def test_render_macro_regime_card_ready_state(monkeypatch):
+    signals, calls = _load_signals_with_fake_streamlit(monkeypatch)
 
     signals.render_macro_regime_card(
         {
+            "status": "ok",
             "regime": "risk_on",
             "confidence": 0.8,
             "drivers": ["금리 하락 방향", "실업률 안정", "CPI 둔화", "ignored"],
             "as_of": "2026-02-22T18:30:00Z",
+            "lineage_id": "run-123",
             "source_tags": ["macro_analysis_results"],
             "freshness_days": 7,
-            "evidence_hard": ["FRED:CPIAUCSL 3m down", "FRED:UNRATE stable"],
+            "evidence_hard": ["FRED:CPIAUCSL 3m down"],
             "evidence_soft": ["Fed commentary softer"],
         }
     )
 
     assert calls["subheader"] == ["Macro regime signal"]
-    assert calls["markdown"] == ["### 🟢 Risk-On"]
-    assert calls["caption"] == [
-        "as_of: 2026-02-22T18:30:00Z",
-        "source_tags: macro_analysis_results",
-        "freshness_policy: stale after 7d",
-    ]
+    assert "### ✅ READY" in calls["markdown"]
+    assert "#### Regime: 🟢 Risk-On" in calls["markdown"]
     assert calls["progress"] == [0.8]
-    assert "핵심 드라이버 (Top 3):" in calls["write"]
-    assert calls["write"].count("• 금리 하락 방향") == 1
-    assert calls["write"].count("• 실업률 안정") == 1
-    assert calls["write"].count("• CPI 둔화") == 1
-    assert "HARD evidence:" in calls["write"]
-    assert "SOFT evidence:" in calls["write"]
-    assert calls["write"].count("• FRED:CPIAUCSL 3m down") == 1
-    assert calls["write"].count("• Fed commentary softer") == 1
+    assert "Data freshness & lineage" in calls["write"]
+    assert "as_of: 2026-02-22T18:30:00Z" in calls["caption"]
+    assert "freshness_threshold: 7d" in calls["caption"]
+    assert "lineage_id: run-123" in calls["caption"]
+    assert "source_tags: macro_analysis_results" in calls["caption"]
 
 
-def test_render_macro_regime_card_placeholder_when_data_missing(monkeypatch):
-    calls: dict[str, list] = {"subheader": [], "info": [], "warning": [], "caption": []}
-
-    fake_streamlit = types.SimpleNamespace(
-        subheader=lambda text: calls["subheader"].append(text),
-        info=lambda text: calls["info"].append(text),
-        warning=lambda text: calls["warning"].append(text),
-        caption=lambda text: calls["caption"].append(text),
-    )
-
-    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
-    sys.modules.pop("src.enduser.signals", None)
-    signals = importlib.import_module("src.enduser.signals")
+def test_render_macro_regime_card_missing_state(monkeypatch):
+    signals, calls = _load_signals_with_fake_streamlit(monkeypatch)
 
     signals.render_macro_regime_card(None)
 
-    assert calls["subheader"] == ["Macro regime signal"]
-    assert calls["info"] == ["No macro regime signal yet. Analysis pipeline data is pending."]
-    assert calls["warning"] == []
-    assert calls["caption"] == ["next_action: run macro-analysis ingestion and refresh Signals tab"]
+    assert "### 🟨 MISSING" in calls["markdown"]
+    assert calls["warning"]
+    assert any("Block signal-based investment action" in text for text in calls["warning"])
+    assert calls["button"] == [("Request data refresh", "macro_refresh_request")]
 
 
-def test_render_macro_regime_card_shows_freshness_policy_when_zero_days(monkeypatch):
-    calls: dict[str, list] = {"caption": []}
-
-    fake_streamlit = types.SimpleNamespace(
-        subheader=lambda *_: None,
-        markdown=lambda *_: None,
-        caption=lambda text: calls["caption"].append(text),
-        write=lambda *_: None,
-        progress=lambda *_: None,
-        info=lambda *_: None,
-        warning=lambda *_: None,
-    )
-
-    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
-    sys.modules.pop("src.enduser.signals", None)
-    signals = importlib.import_module("src.enduser.signals")
+def test_render_macro_regime_card_stale_state(monkeypatch):
+    signals, calls = _load_signals_with_fake_streamlit(monkeypatch)
 
     signals.render_macro_regime_card(
         {
+            "status": "stale",
+            "message": "Latest macro regime signal is stale (> 7 days).",
             "regime": "neutral",
-            "confidence": 0.5,
-            "as_of": "2026-02-22T00:00:00Z",
-            "freshness_days": 0,
+            "confidence": 0.4,
+            "as_of": "2026-02-01T00:00:00Z",
+            "freshness_days": 7,
         }
     )
 
-    assert "freshness_policy: stale after 0d" in calls["caption"]
+    assert "### ⚠️ STALE" in calls["markdown"]
+    assert "Latest macro regime signal is stale (> 7 days)." in calls["warning"]
+    assert any("Do not execute new thesis entries" in text for text in calls["warning"])
+    assert "as_of: 2026-02-01T00:00:00Z" in calls["caption"]
 
 
-def test_render_macro_regime_card_shows_stale_state(monkeypatch):
-    calls: dict[str, list] = {"subheader": [], "warning": [], "caption": []}
-
-    fake_streamlit = types.SimpleNamespace(
-        subheader=lambda text: calls["subheader"].append(text),
-        warning=lambda text: calls["warning"].append(text),
-        markdown=lambda *_: None,
-        caption=lambda text: calls["caption"].append(text),
-        write=lambda *_: None,
-        progress=lambda *_: None,
-    )
-
-    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
-    sys.modules.pop("src.enduser.signals", None)
-    signals = importlib.import_module("src.enduser.signals")
+def test_render_macro_regime_card_error_state_and_refresh_hook(monkeypatch):
+    signals, calls = _load_signals_with_fake_streamlit(monkeypatch, button_return=True)
 
     signals.render_macro_regime_card(
-        {"status": "stale", "message": "Latest macro regime signal is stale (> 7 days).", "regime": "neutral", "confidence": 0.4, "as_of": "2026-02-01T00:00:00Z"}
+        {
+            "status": "error",
+            "message": "Latest macro regime row is malformed.",
+            "freshness_days": 7,
+        }
     )
 
-    assert calls["subheader"] == ["Macro regime signal"]
-    assert calls["warning"] == ["[stale] Latest macro regime signal is stale (> 7 days)."]
-    assert calls["caption"] == ["next_action: rerun macro-analysis pipeline to refresh as_of", "as_of: 2026-02-01T00:00:00Z"]
+    assert "### 🛑 ERROR" in calls["markdown"]
+    assert "Latest macro regime row is malformed." in calls["error"]
+    assert any("Block signal-based investment action" in text for text in calls["error"])
+    assert any("Refresh request recorded." in text for text in calls["info"])


### PR DESCRIPTION
## Why
Signals tab surfaced stale/missing/error states with internal next_action-style captions, leaving end users without decision-grade guidance at the key decision surface.

## What
- Added normalized readiness panel for macro regime card: READY, STALE, MISSING, ERROR
- Added explicit decision guidance copy for each readiness state (including block/defer guidance for non-ready states)
- Added user-facing Data freshness & lineage section (as_of, freshness threshold, lineage_id, source_tags when present)
- Removed internal next_action debug-style captions from end-user view
- Added a non-blocking Request data refresh CTA hook (UI event only)
- Expanded UI unit coverage for all four readiness states and refresh CTA behavior

## Validation
- `pytest -q tests/test_signals_ui.py tests/test_enduser_macro_signal_service.py`
- `FRED_API_KEY= ECOS_API_KEY= pytest -q`

Closes #145
