### PR TITLE
feat(portfolio): add allocation/leverage guardrail UI in portfolio tab

### DIFF
--- a/src/enduser/app.py
+++ b/src/enduser/app.py
@@ -26,6 +26,15 @@ def _format_ratio(value: object, precision: int = 2) -> str:
         return "n/a"
 
 
+def _format_pp(value: object, precision: int = 2) -> str:
+    try:
+        if value is None:
+            return "n/a"
+        return f"{float(value):.{precision}f}%p"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
 def _render_portfolio_tab(st: object, dsn: str) -> None:
     repository = PostgresRepository(dsn=dsn)
     performance = build_performance_view(repository)
@@ -47,11 +56,17 @@ def _render_portfolio_tab(st: object, dsn: str) -> None:
     c4.metric("알파(vs 벤치마크)", _format_pct(alpha_pct))
 
     if bool(performance.get("mdd_alert")):
-        threshold = performance.get("mdd_alert_threshold_pct")
-        st.warning(
-            "MDD 경보: 하락폭이 경보 임계치에 접근/도달했습니다 "
-            f"(threshold={_format_pct(threshold)})."
-        )
+        policy_limit_pct = performance.get("policy_mdd_limit_pct")
+        mdd_policy_buffer_pp = performance.get("mdd_policy_buffer_pp")
+        if mdd_policy_buffer_pp is not None and float(mdd_policy_buffer_pp) > 0:
+            st.warning(
+                f"⚠️ MDD {_format_pct(mdd_pct)} — 정책 한계({_format_pct(policy_limit_pct)})까지 "
+                f"{_format_pp(mdd_policy_buffer_pp)} 남음"
+            )
+        else:
+            st.warning(
+                f"⚠️ MDD {_format_pct(mdd_pct)} — 정책 한계({_format_pct(policy_limit_pct)})를 초과했습니다"
+            )
 
     benchmark_series = performance.get("benchmark_series", [])
     benchmark_map: dict[str, float] = {}
@@ -96,6 +111,33 @@ def _render_portfolio_tab(st: object, dsn: str) -> None:
             x="as_of",
             y=["portfolio_nav_index", "benchmark_nav_index"],
         )
+
+    allocation_pairs = [
+        ("US", performance.get("us_weight_pct")),
+        ("KR", performance.get("kr_weight_pct")),
+        ("Crypto", performance.get("crypto_weight_pct")),
+        ("기타", performance.get("other_weight_pct")),
+    ]
+    allocation_chart = {
+        label: [float(weight)]
+        for label, weight in allocation_pairs
+        if weight is not None
+    }
+    if allocation_chart:
+        st.subheader("자산 배분")
+        st.bar_chart(allocation_chart)
+        st.caption("정책 목표 가이드: US ~45% · KR ~25% · Crypto ~20%")
+
+    leverage_weight_pct = performance.get("leverage_weight_pct")
+    leverage_cap_pct = performance.get("leverage_cap_pct")
+    if leverage_weight_pct is not None and leverage_cap_pct is not None:
+        leverage_message = (
+            f"레버리지 슬리브: {_format_pct(leverage_weight_pct)} / {_format_pct(leverage_cap_pct)} 상한"
+        )
+        if bool(performance.get("leverage_cap_breached")):
+            st.warning(f"⚠️ {leverage_message}")
+        else:
+            st.caption(leverage_message)
 
 
 def run_enduser_app(dsn: str, *, configure_page: bool = True) -> None:

--- a/src/enduser/performance_service.py
+++ b/src/enduser/performance_service.py
@@ -10,6 +10,8 @@ from src.enduser.benchmark_service import compute_benchmark_series
 
 
 DEFAULT_MDD_ALERT_THRESHOLD = -0.20
+DEFAULT_POLICY_MDD_LIMIT = -0.30
+DEFAULT_LEVERAGE_CAP = 0.20
 
 
 def _parse_as_of(raw: object) -> date | None:
@@ -17,11 +19,13 @@ def _parse_as_of(raw: object) -> date | None:
         return raw.date()
     if isinstance(raw, date):
         return raw
+
     text = str(raw).strip()
     if not text:
         return None
     if text.endswith("Z"):
         text = text[:-1] + "+00:00"
+
     try:
         return datetime.fromisoformat(text).date()
     except ValueError:
@@ -40,15 +44,28 @@ def _to_float(raw: object) -> float | None:
     return value
 
 
-def _load_mdd_alert_threshold() -> float:
-    raw = os.getenv("MDD_ALERT_THRESHOLD")
+def _to_weight_pct(raw: object) -> float | None:
+    value = _to_float(raw)
+    if value is None or value < 0:
+        return None
+
+    # DB usually stores weights in [0, 1], but tolerate percent input for robustness.
+    if value <= 1.0:
+        return value * 100.0
+    if value <= 100.0:
+        return value
+    return None
+
+
+def _load_negative_ratio(name: str, default: float) -> float:
+    raw = os.getenv(name)
     if raw is None or raw.strip() == "":
-        return DEFAULT_MDD_ALERT_THRESHOLD
+        return default
 
     try:
         parsed = float(raw)
     except ValueError:
-        return DEFAULT_MDD_ALERT_THRESHOLD
+        return default
 
     if parsed > 0:
         parsed = -parsed
@@ -57,7 +74,37 @@ def _load_mdd_alert_threshold() -> float:
         parsed = parsed / 100.0
 
     if parsed > 0 or parsed < -1.0:
-        return DEFAULT_MDD_ALERT_THRESHOLD
+        return default
+
+    return parsed
+
+
+def _load_mdd_alert_threshold() -> float:
+    return _load_negative_ratio("MDD_ALERT_THRESHOLD", DEFAULT_MDD_ALERT_THRESHOLD)
+
+
+def _load_policy_mdd_limit() -> float:
+    return _load_negative_ratio("MDD_POLICY_LIMIT", DEFAULT_POLICY_MDD_LIMIT)
+
+
+def _load_leverage_cap() -> float:
+    raw = os.getenv("LEVERAGE_CAP")
+    if raw is None or raw.strip() == "":
+        return DEFAULT_LEVERAGE_CAP
+
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return DEFAULT_LEVERAGE_CAP
+
+    if parsed < 0:
+        return DEFAULT_LEVERAGE_CAP
+
+    if parsed > 1.0:
+        parsed = parsed / 100.0
+
+    if parsed < 0 or parsed > 1.0:
+        return DEFAULT_LEVERAGE_CAP
 
     return parsed
 
@@ -109,17 +156,29 @@ def _compute_sharpe_ratio(daily_returns: list[float]) -> float | None:
 def build_performance_view(repository: object, limit: int = 365) -> dict[str, Any]:
     rows = repository.read_portfolio_snapshots(limit=limit) if hasattr(repository, "read_portfolio_snapshots") else []
 
-    nav_points: list[tuple[date, float]] = []
+    snapshots: list[dict[str, Any]] = []
     for row in rows:
         if not isinstance(row, dict):
             continue
+
         as_of = _parse_as_of(row.get("as_of"))
         nav = _to_float(row.get("nav"))
         if as_of is None or nav is None or nav <= 0:
             continue
-        nav_points.append((as_of, nav))
 
-    nav_points = sorted(nav_points, key=lambda item: item[0])
+        snapshots.append(
+            {
+                "as_of": as_of,
+                "nav": nav,
+                "us_weight_pct": _to_weight_pct(row.get("us_weight")),
+                "kr_weight_pct": _to_weight_pct(row.get("kr_weight")),
+                "crypto_weight_pct": _to_weight_pct(row.get("crypto_weight")),
+                "leverage_weight_pct": _to_weight_pct(row.get("leverage_weight")),
+            }
+        )
+
+    snapshots.sort(key=lambda item: item["as_of"])
+    nav_points: list[tuple[date, float]] = [(item["as_of"], item["nav"]) for item in snapshots]
 
     nav_series: list[dict[str, Any]] = []
     for idx, (as_of, nav) in enumerate(nav_points):
@@ -161,16 +220,50 @@ def build_performance_view(repository: object, limit: int = 365) -> dict[str, An
         alpha = total_return - benchmark_total_return
 
     mdd_alert_threshold = _load_mdd_alert_threshold()
+    policy_mdd_limit = _load_policy_mdd_limit()
+    leverage_cap = _load_leverage_cap()
+
     # Floating-point safety for threshold edge values (e.g. -0.2 exactly).
     mdd_alert = bool(mdd is not None and mdd <= (mdd_alert_threshold + 1e-9))
 
+    latest_snapshot = snapshots[-1] if snapshots else None
+    us_weight_pct = latest_snapshot.get("us_weight_pct") if latest_snapshot else None
+    kr_weight_pct = latest_snapshot.get("kr_weight_pct") if latest_snapshot else None
+    crypto_weight_pct = latest_snapshot.get("crypto_weight_pct") if latest_snapshot else None
+    leverage_weight_pct = latest_snapshot.get("leverage_weight_pct") if latest_snapshot else None
+
+    known_total = sum(v for v in [us_weight_pct, kr_weight_pct, crypto_weight_pct] if v is not None)
+    other_weight_pct = (
+        max(0.0, 100.0 - known_total)
+        if any(v is not None for v in [us_weight_pct, kr_weight_pct, crypto_weight_pct])
+        else None
+    )
+
+    mdd_pct = mdd * 100 if mdd is not None else None
+    policy_mdd_limit_pct = policy_mdd_limit * 100
+    mdd_policy_buffer_pp = max(0.0, mdd_pct - policy_mdd_limit_pct) if mdd_pct is not None else None
+
+    leverage_cap_pct = leverage_cap * 100
+    leverage_cap_breached = bool(
+        leverage_weight_pct is not None and leverage_weight_pct > (leverage_cap_pct + 1e-9)
+    )
+
     return {
         "total_return_pct": total_return * 100 if total_return is not None else None,
-        "mdd_pct": mdd * 100 if mdd is not None else None,
+        "mdd_pct": mdd_pct,
         "sharpe_ratio": sharpe,
         "alpha_pct": alpha * 100 if alpha is not None else None,
         "mdd_alert": mdd_alert,
         "mdd_alert_threshold_pct": mdd_alert_threshold * 100,
+        "policy_mdd_limit_pct": policy_mdd_limit_pct,
+        "mdd_policy_buffer_pp": mdd_policy_buffer_pp,
+        "us_weight_pct": us_weight_pct,
+        "kr_weight_pct": kr_weight_pct,
+        "crypto_weight_pct": crypto_weight_pct,
+        "other_weight_pct": other_weight_pct,
+        "leverage_weight_pct": leverage_weight_pct,
+        "leverage_cap_pct": leverage_cap_pct,
+        "leverage_cap_breached": leverage_cap_breached,
         "nav_series": nav_series,
         "benchmark_series": benchmark_series,
     }

--- a/tests/test_enduser_app_smoke.py
+++ b/tests/test_enduser_app_smoke.py
@@ -153,8 +153,8 @@ def test_render_portfolio_tab_shows_empty_info_when_no_snapshot(monkeypatch):
     assert calls["line_chart"] == []
 
 
-def test_render_portfolio_tab_renders_metrics_and_line_chart(monkeypatch):
-    calls: dict[str, object] = {"metrics": [], "line_chart": []}
+def test_render_portfolio_tab_renders_metrics_chart_allocation_and_leverage(monkeypatch):
+    calls: dict[str, object] = {"metrics": [], "line_chart": [], "bar_chart": []}
 
     class _Column:
         def metric(self, label: str, value: str):
@@ -163,17 +163,28 @@ def test_render_portfolio_tab_renders_metrics_and_line_chart(monkeypatch):
     fake_streamlit = types.SimpleNamespace(
         info=lambda text: calls.setdefault("info", []).append(text),
         warning=lambda text: calls.setdefault("warning", []).append(text),
+        caption=lambda text: calls.setdefault("caption", []).append(text),
+        subheader=lambda text: calls.setdefault("subheader", []).append(text),
         columns=lambda count: [_Column() for _ in range(count)],
         line_chart=lambda *args, **kwargs: calls["line_chart"].append((args, kwargs)),
+        bar_chart=lambda *args, **kwargs: calls["bar_chart"].append((args, kwargs)),
     )
 
     performance_payload = {
         "total_return_pct": 12.34,
-        "mdd_pct": -8.5,
+        "mdd_pct": -21.0,
         "sharpe_ratio": 1.23,
         "alpha_pct": 2.5,
         "mdd_alert": True,
-        "mdd_alert_threshold_pct": -20,
+        "policy_mdd_limit_pct": -30.0,
+        "mdd_policy_buffer_pp": 9.0,
+        "us_weight_pct": 45.0,
+        "kr_weight_pct": 25.0,
+        "crypto_weight_pct": 20.0,
+        "other_weight_pct": 10.0,
+        "leverage_weight_pct": 25.0,
+        "leverage_cap_pct": 20.0,
+        "leverage_cap_breached": True,
         "nav_series": [
             {"as_of": "2026-01-01", "nav": 1000},
             {"as_of": "2026-01-02", "nav": 1100},
@@ -192,7 +203,11 @@ def test_render_portfolio_tab_renders_metrics_and_line_chart(monkeypatch):
     labels = [label for label, _ in calls["metrics"]]
     assert labels == ["총수익률", "MDD", "Sharpe", "알파(vs 벤치마크)"]
     assert calls["line_chart"], "expected line_chart call"
-    assert calls.get("warning"), "expected mdd alert warning"
+    assert calls["bar_chart"], "expected allocation chart"
+    assert "자산 배분" in calls.get("subheader", [])
+    warnings = calls.get("warning", [])
+    assert any("MDD" in text for text in warnings)
+    assert any("레버리지 슬리브" in text for text in warnings)
 
 
 def test_enduser_entrypoint_requires_database_url(monkeypatch):

--- a/tests/test_performance_service.py
+++ b/tests/test_performance_service.py
@@ -21,6 +21,14 @@ def test_build_performance_view_returns_empty_metrics_when_no_snapshots(monkeypa
     assert view["sharpe_ratio"] is None
     assert view["alpha_pct"] is None
     assert view["mdd_alert"] is False
+    assert view["policy_mdd_limit_pct"] == pytest.approx(-30.0)
+    assert view["us_weight_pct"] is None
+    assert view["kr_weight_pct"] is None
+    assert view["crypto_weight_pct"] is None
+    assert view["other_weight_pct"] is None
+    assert view["leverage_weight_pct"] is None
+    assert view["leverage_cap_pct"] == pytest.approx(20.0)
+    assert view["leverage_cap_breached"] is False
     assert view["nav_series"] == []
     assert view["benchmark_series"] == []
 
@@ -31,10 +39,38 @@ def test_build_performance_view_computes_total_return_mdd_sharpe_and_alpha(monke
             assert limit == 365
             # Repository returns newest-first; service should normalize to chronological order.
             return [
-                {"as_of": "2026-01-04", "nav": 120},
-                {"as_of": "2026-01-03", "nav": 100},
-                {"as_of": "2026-01-02", "nav": 80},
-                {"as_of": "2026-01-01", "nav": 100},
+                {
+                    "as_of": "2026-01-04",
+                    "nav": 120,
+                    "us_weight": 0.45,
+                    "kr_weight": 0.25,
+                    "crypto_weight": 0.20,
+                    "leverage_weight": 0.10,
+                },
+                {
+                    "as_of": "2026-01-03",
+                    "nav": 100,
+                    "us_weight": 0.45,
+                    "kr_weight": 0.25,
+                    "crypto_weight": 0.20,
+                    "leverage_weight": 0.10,
+                },
+                {
+                    "as_of": "2026-01-02",
+                    "nav": 80,
+                    "us_weight": 0.45,
+                    "kr_weight": 0.25,
+                    "crypto_weight": 0.20,
+                    "leverage_weight": 0.10,
+                },
+                {
+                    "as_of": "2026-01-01",
+                    "nav": 100,
+                    "us_weight": 0.45,
+                    "kr_weight": 0.25,
+                    "crypto_weight": 0.20,
+                    "leverage_weight": 0.10,
+                },
             ]
 
     benchmark_rows = [
@@ -58,6 +94,15 @@ def test_build_performance_view_computes_total_return_mdd_sharpe_and_alpha(monke
     assert view["sharpe_ratio"] == pytest.approx(5.36, abs=0.01)
     # Alpha = 20.0% - 3.0%
     assert view["alpha_pct"] == pytest.approx(17.0)
+    assert view["policy_mdd_limit_pct"] == pytest.approx(-30.0)
+    assert view["mdd_policy_buffer_pp"] == pytest.approx(10.0)
+    assert view["us_weight_pct"] == pytest.approx(45.0)
+    assert view["kr_weight_pct"] == pytest.approx(25.0)
+    assert view["crypto_weight_pct"] == pytest.approx(20.0)
+    assert view["other_weight_pct"] == pytest.approx(10.0)
+    assert view["leverage_weight_pct"] == pytest.approx(10.0)
+    assert view["leverage_cap_pct"] == pytest.approx(20.0)
+    assert view["leverage_cap_breached"] is False
     assert [row["as_of"] for row in view["nav_series"]] == [
         "2026-01-01",
         "2026-01-02",
@@ -83,3 +128,35 @@ def test_build_performance_view_respects_mdd_alert_threshold_override(monkeypatc
     assert view["mdd_pct"] == pytest.approx(-10.0)
     assert view["mdd_alert"] is False
     assert view["mdd_alert_threshold_pct"] == pytest.approx(-25.0)
+
+
+def test_build_performance_view_respects_leverage_cap_override(monkeypatch):
+    class FakeRepository:
+        def read_portfolio_snapshots(self, limit: int = 365):
+            return [
+                {
+                    "as_of": "2026-01-02",
+                    "nav": 101,
+                    "us_weight": 0.40,
+                    "kr_weight": 0.25,
+                    "crypto_weight": 0.20,
+                    "leverage_weight": 0.18,
+                },
+                {
+                    "as_of": "2026-01-01",
+                    "nav": 100,
+                    "us_weight": 0.40,
+                    "kr_weight": 0.25,
+                    "crypto_weight": 0.20,
+                    "leverage_weight": 0.18,
+                },
+            ]
+
+    monkeypatch.setattr(performance_service, "compute_benchmark_series", lambda repository, start_date, end_date: [])
+    monkeypatch.setenv("LEVERAGE_CAP", "15")
+
+    view = performance_service.build_performance_view(FakeRepository())
+
+    assert view["leverage_weight_pct"] == pytest.approx(18.0)
+    assert view["leverage_cap_pct"] == pytest.approx(15.0)
+    assert view["leverage_cap_breached"] is True


### PR DESCRIPTION
## Why
Issue #98 asks for portfolio guardrail UX completion in the End-user app:
- asset allocation visualization (US/KR/Crypto/기타)
- leverage sleeve vs 20% cap highlighting
- MDD warning banner tied to policy limit context

## What
### 1) Performance service enrichment
- `src/enduser/performance_service.py`
  - keep existing performance metrics (`total_return_pct`, `mdd_pct`, `sharpe_ratio`, `alpha_pct`)
  - add latest allocation fields:
    - `us_weight_pct`, `kr_weight_pct`, `crypto_weight_pct`, `other_weight_pct`
    - `leverage_weight_pct`
  - add policy/guardrail fields:
    - `policy_mdd_limit_pct` (default -30%, env override: `MDD_POLICY_LIMIT`)
    - `mdd_policy_buffer_pp`
    - `leverage_cap_pct` (default 20%, env override: `LEVERAGE_CAP`)
    - `leverage_cap_breached`
  - keep `MDD_ALERT_THRESHOLD` override behavior

### 2) End-user Portfolio tab UI
- `src/enduser/app.py`
  - render MDD guardrail warning banner in policy-friendly wording:
    - `⚠️ MDD -XX% — 정책 한계(-30%)까지 XX%p 남음`
  - render allocation bar chart (`st.bar_chart`) for US/KR/Crypto/기타
  - render leverage sleeve status text and warning when cap breached

### 3) Test coverage
- `tests/test_performance_service.py`
  - add checks for allocation + guardrail fields
  - add leverage cap override test
- `tests/test_enduser_app_smoke.py`
  - verify portfolio tab renders:
    - metric cards
    - NAV line chart
    - allocation chart
    - MDD warning + leverage warning paths

## Validation
- `pytest -q tests/test_performance_service.py tests/test_enduser_app_smoke.py` (9 passed)
- `FRED_API_KEY= ECOS_API_KEY= pytest -q` (188 passed)

## Issue
- Closes #98
